### PR TITLE
feat/contests-creation

### DIFF
--- a/backend/helper/FantasyStoreHelper.mo
+++ b/backend/helper/FantasyStoreHelper.mo
@@ -1,11 +1,8 @@
 
-import Types "../model/Types";
-
+import Int "mo:base/Int";
 module FantasyStoreHelper {
 
-  type Key = Types.Key;
-  type User = Types.User;
-  type Users = Types.Users;
+ // Constants
   let millisecondsPerDay : Int = 86400000; //24 * 60 * 60 * 1000;
 
   // Function to extract year, month, and day from a timestamp in milliseconds
@@ -52,10 +49,16 @@ module FantasyStoreHelper {
 
     return (year, month, day);
   };
-  // Function to compare two timestamps and return true if they fall on the same day
+  // Function to compare two timestamps and return true if they fall on the same dayisSameDay
   public func isSameDay(timestamp1 : Int, timestamp2 : Int) : Bool {
     let (year1, month1, day1) = getDateParts(timestamp1);
     let (year2, month2, day2) = getDateParts(timestamp2);
+    return year2 == year1 and month2 == month1 and day2 == day1;
+  };
+
+  public func isSameDayWithOffset(timestamp1 : Int, timestamp2 : Int,offset:Int) : Bool {
+    let (year1, month1, day1) = getDateParts(timestamp1+offset);
+    let (year2, month2, day2) = getDateParts(timestamp2+offset);
     return year2 == year1 and month2 == month1 and day2 == day1;
   };
 

--- a/backend/model/Types.mo
+++ b/backend/model/Types.mo
@@ -199,6 +199,110 @@ public type InputMatch = {
     homeScore : Nat;
     awayScore : Nat;
   };
+   public type ContestCommon = {
+    providerId : MonkeyId;
+    matchId : Key;
+    name : Text;
+    slots : Nat;
+    minCap : Nat;
+    maxCap : Nat;
+    teamsPerUser : Nat;
+    rules : Text;
+  };
+  public type Contest = ContestCommon and {
+    creatorUserId : Key;
+    slotsUsed : Nat;
+  };
+    public type Participant = {
+    contestId : Key;
+    userId : Key;
+    squadId : Key;
+    rank : Nat;
+  };
+    public type Participants = [(Key, Participant)];
+public type IPlayerSquad = {
+    // providerId : MonkeyId;
+    name : Text;
+    matchId : Key;
+    cap : Key;
+    viceCap : Key;
+    players : [(Key, Bool)];
+    formation : Text;
+  };
+    public type PlayerSquadCommon = {
+    userId : Key;
+    name : Text;
+    matchId : Key;
+    cap : Key;
+    viceCap : Key;
+    formation : Text;
+    creation_time : Int;
+    rank : Nat;
+    points : RPoints;
+    hasParticipated : Bool;
+  };
+    public type PlayerSquad = PlayerSquadCommon and {
+    players : [(Key, Bool)];
+  };
+    public type ListPlayerSquad = PlayerSquadCommon and {
+    points : RPoints;
+    joinedContestsName : [Text];
+  };
+   public type RefinedPlayerSquad = PlayerSquadCommon and {
+    // providerId : MonkeyId;
+    players : [(Key, PlayerS, Bool)];
+  };
+   public type RefinedPlayerSquadRanking = {
+    // providerId : MonkeyId;
+    userId : Key;
+    name : Text;
+    matchId : Key;
+    points : RPoints;
+    creation_time : Int;
+    rank : Nat;
+  };
+    public type RawPlayerSquad = PlayerSquadCommon and {
+    matchTime : Int;
+    points : RPoints;
+    matchName : Text;
+  };
+ public type PlayerSquads = [(Key, PlayerSquad)];
+  public type ListPlayerSquads = [(Key, ListPlayerSquad)];
+  public type RefinedPlayerSquads = [(Key, RefinedPlayerSquad)];
+  public type RefinedPlayerSquadRankings = [(Key, RefinedPlayerSquadRanking)];
+  public type RawPlayerSquads = [(Key, RawPlayerSquad)];
+  public type ContestWithMatch = ContestCommon and {
+    creatorUserId : Key;
+    slotsUsed : Nat;
+    homeTeamName : Text;
+    awayTeamName : Text;
+    awayScore : Nat;
+    homeScore : Nat;
+  };
+
+  public type DetailedContest = Contest and {
+    teamsJoinedContest : Nat;
+    teamsCreatedOnContest : Nat;
+
+  };
+
+  public type ContestArray = [DetailedContest];
+  public type DetailedMatchContest = RMatch and {
+    latest : Bool;
+    contests : ContestArray;
+    providerId : Key;
+    teamsCreated : Nat;
+    teamsJoined : Nat;
+  };
+  // Contest with matchName
+  public type MatchContest = Contest and {
+    matchName : Text;
+    homeTeamName : Text;
+    awayTeamName : Text;
+    awayScore : Nat;
+    homeScore : Nat;
+  };
+  public type IContest = ContestCommon;
   public type ITournament = {
     id : Key;
     providerId : MonkeyId;
@@ -207,6 +311,15 @@ public type InputMatch = {
     description : Text;
     startDate : Int;
     endDate : Int;
+  };
+  public type ContestsWithId = [(Key, ContestWithMatch)];
+ public type DetailedMatchContests = [DetailedMatchContest];
+  public type RMatchContest = [MatchContest];
+    public type MatchContests = [(Key, MatchContest)];
+  public type Contests = [(Key, Contest)];
+ public type RankPlayerSquad = RefinedPlayerSquad and {
+    // providerId : MonkeyId;
+    ranks : [(Key, Nat)];
   };
 
  public type ITeamWithPlayers = {
@@ -229,14 +342,11 @@ public type InputMatch = {
     homeScore : Nat;
     awayScore : Nat;
   };
+    public let MAX_PLAYER_PER_SQUAD = 15;
  public let AdminSettings = {
     budget = "budget";
     platformPercentage = "platformPercentage";
-    contestWinnerReward = "contestWinnerReward";
-    rewardableUsersPercentage = "rewardableUsersPercentage";
-    referalFirstPositionPercentage = "referalFirstPositionPercentage";
-    referalSecondPositionPercentage = "referalSecondPositionPercentage";
-    referalThirdPositionPercentage = "referalThirdPositionPercentage";
+
 
   };
   public func generateNewRemoteObjectId() : Key {

--- a/backend/model/Validation.mo
+++ b/backend/model/Validation.mo
@@ -1,0 +1,315 @@
+import Text "mo:base/Text";
+import Nat "mo:base/Nat";
+import Bool "mo:base/Bool";
+import Result "mo:base/Result";
+import Char "mo:base/Char";
+import Nat32 "mo:base/Nat32";
+import Map "mo:base/HashMap";
+import Types "./Types";
+
+module Validation {
+  type Player = Types.Player;
+  type Formation = {
+    goalKeeper : Nat;
+    defender : Nat;
+    midfielder : Nat;
+    forward : Nat;
+  };
+
+  type Substitution = {
+    goalKeeper : Nat;
+    defender : Nat;
+    midfielder : Nat;
+    forward : Nat;
+  };
+
+  type FormationAndSubstitution = {
+    formation : Formation;
+    substitution : Substitution;
+  };
+
+  let FORMATIONS_AND_SUBSTITUTION : [FormationAndSubstitution] = [
+    {
+      formation = { goalKeeper = 1; defender = 3; midfielder = 4; forward = 3 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 2;
+        midfielder = 1;
+        forward = 0;
+      };
+    },
+    {
+      formation = { goalKeeper = 1; defender = 3; midfielder = 5; forward = 2 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 2;
+        midfielder = 0;
+        forward = 1;
+      };
+    },
+    {
+      formation = { goalKeeper = 1; defender = 4; midfielder = 3; forward = 3 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 1;
+        midfielder = 2;
+        forward = 0;
+      };
+    },
+    {
+      formation = { goalKeeper = 1; defender = 4; midfielder = 4; forward = 2 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 1;
+        midfielder = 1;
+        forward = 1;
+      };
+    },
+    {
+      formation = { goalKeeper = 1; defender = 4; midfielder = 5; forward = 1 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 1;
+        midfielder = 0;
+        forward = 2;
+      };
+    },
+    {
+      formation = { goalKeeper = 1; defender = 5; midfielder = 2; forward = 3 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 0;
+        midfielder = 3;
+        forward = 0;
+      };
+    },
+    {
+      formation = { goalKeeper = 1; defender = 5; midfielder = 3; forward = 2 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 0;
+        midfielder = 2;
+        forward = 1;
+      };
+    },
+    {
+      formation = { goalKeeper = 1; defender = 5; midfielder = 4; forward = 1 };
+      substitution = {
+        goalKeeper = 1;
+        defender = 0;
+        midfielder = 1;
+        forward = 2;
+      };
+    },
+  ];
+   func getFormation(formationString : Text) : ?FormationAndSubstitution {
+
+    //   let parts = Text.split(arg, #char '-');
+    var currentFormation = {
+      defender = 0;
+      midfielder = 0;
+      forward = 0;
+    };
+    var index = 1;
+    //     var list = List.nil<Nat>();
+
+    for (chr in Text.toArray(formationString).vals()) {
+      if (index == 1) {
+        let charToNum = Nat32.toNat(Char.toNat32(chr) -48);
+
+        currentFormation := { currentFormation with defender = charToNum };
+
+      };
+      if (index == 3) {
+        let charToNum = Nat32.toNat(Char.toNat32(chr) -48);
+
+        currentFormation := { currentFormation with midfielder = charToNum };
+
+      };
+      if (index == 5) {
+        let charToNum = Nat32.toNat(Char.toNat32(chr) -48);
+
+        currentFormation := { currentFormation with forward = charToNum };
+
+      };
+      index += 1;
+    };
+
+    var tempFormation : ?FormationAndSubstitution = null;
+
+    label formationloop for (formationSubst in FORMATIONS_AND_SUBSTITUTION.vals()) {
+      if (
+        formationSubst.formation.defender == currentFormation.defender and formationSubst.formation.midfielder == currentFormation.midfielder and formationSubst.formation.forward == currentFormation.forward
+      ) {
+        tempFormation := ?formationSubst;
+        break formationloop;
+      };
+    };
+    return tempFormation;
+
+  };
+  func compareFormations(f1: Formation, f2: Formation): Bool {
+    return f1.goalKeeper == f2.goalKeeper
+      and f1.defender == f2.defender
+      and f1.midfielder == f2.midfielder
+      and f1.forward == f2.forward;
+  };
+// this function check what ever user hs selected player according to formation or not
+  public func validateTeamFormation(inputPlayers : [(Text, Bool)], teamFormation : Text, playerStorage : Map.HashMap<Text, Player>) : Result.Result<Text, Text> {
+
+    let _getFormation = getFormation(teamFormation);
+    switch (_getFormation) {
+      case (null) {
+        return #err("Team Formation Not found.");
+
+      };
+      case (?isFormation) {
+        var playerFormation = {
+          goalKeeper = 0;
+          defender = 0;
+          midfielder = 0;
+          forward = 0;
+        };
+        var substitutionFormation = {
+          goalKeeper = 0;
+          defender = 0;
+          midfielder = 0;
+          forward = 0;
+        };
+        for ((key, isSub) in inputPlayers.vals()) {
+          let getPlayer = playerStorage.get(key);
+          switch (getPlayer) {
+            case (null) {};
+            case (?isPlayer) {
+
+              switch (isPlayer.position) {
+                case (#goalKeeper) {
+                  if (isSub) {
+                    substitutionFormation := {
+                      substitutionFormation with goalKeeper = substitutionFormation.goalKeeper + 1;
+                    }
+
+                  } else {
+
+                    playerFormation := {
+                      playerFormation with goalKeeper = playerFormation.goalKeeper + 1;
+                    };
+                  };
+                };
+                case (#defender) {
+                  if (isSub) {
+                    substitutionFormation := {
+                      substitutionFormation with defender = substitutionFormation.defender + 1;
+                    }
+
+                  } else {
+
+                    playerFormation := {
+                      playerFormation with defender = playerFormation.defender + 1;
+                    };
+                  };
+                };
+                case (#midfielder) {
+                  if (isSub) {
+                    substitutionFormation := {
+                      substitutionFormation with midfielder = substitutionFormation.midfielder + 1;
+                    }
+
+                  } else {
+
+                    playerFormation := {
+                      playerFormation with midfielder = playerFormation.midfielder + 1;
+                    };
+                  };
+                };
+                case (#forward) {
+                  if (isSub) {
+                    substitutionFormation := {
+                      substitutionFormation with forward = substitutionFormation.forward + 1;
+                    }
+
+                  } else {
+
+                    playerFormation := {
+                      playerFormation with forward = playerFormation.forward + 1;
+                    };
+                  };
+                };
+              };
+            };
+          };
+
+        };
+      
+     if(compareFormations(playerFormation, isFormation.formation)  and compareFormations(substitutionFormation, isFormation.substitution)){
+      return #ok("formation is correct");
+
+    }else{
+        let totalPlayerSelected=playerFormation.goalKeeper+playerFormation.defender+playerFormation.midfielder+playerFormation.forward;
+        let totalSubstitutePlayersSelected=substitutionFormation.goalKeeper+substitutionFormation.defender+substitutionFormation.midfielder+substitutionFormation.forward;
+
+        if(totalPlayerSelected != 11){
+        return #err("Please select 11 players");
+        };
+         if(totalSubstitutePlayersSelected != 4){
+        return #err("Please select 4 Substitute");
+        };
+         return #err("Players are not selected according to Formation.");
+
+      }
+      };
+    };
+
+  };
+  // check if user has selected 9 or more then 9 player from single team 
+   public func validateSelectedPlayersAreNotFromSingleTeam(inputPlayers : [(Text, Bool)], homeTeamId : Text,awayTeamId : Text, playerStorage : Map.HashMap<Text, Player>) : Result.Result<Text, Text> {
+var homeTeamPlayers:Nat=0;
+var awayTeamPlayers:Nat=0;
+
+     for ((key, isSub) in inputPlayers.vals()) {
+        let player=playerStorage.get(key);
+        switch(player) {
+            case(null) { };
+            case(?isPlayer) {  
+               if(isPlayer.teamId==homeTeamId){
+                homeTeamPlayers +=1;
+               };
+                if(isPlayer.teamId==awayTeamId){
+                awayTeamPlayers +=1;
+               }
+            };
+        };
+
+     };
+     if(homeTeamPlayers > 9 or awayTeamPlayers > 9){
+        return #err("You can't select more than 9 players from single team.")
+     };
+     return #ok("Players are select right ")
+  };
+
+  // use to check whatever selected players are 15 or not if substitute and players are not 15 then return error
+  public func playersCount(inputPlayers : [(Text, Bool)]) : Result.Result<Text, Text> {
+    var playerCount : Nat = 0;
+    var substituteCount : Nat = 0;
+
+    for ((_, isSubstitute) in inputPlayers.vals()) {
+      if (isSubstitute) {
+        substituteCount += 1;
+      } else {
+        playerCount += 1;
+      };
+    };
+
+    // Check if there are exactly 11 players and 4 substitutes
+    if (playerCount != 11) {
+
+      return #err("There must be exactly 11 players.");
+    };
+    if (substituteCount != 4) {
+      return #err("There must be exactly 4 substitutes.");
+    };
+    return #ok("15 players are selected");
+
+  };
+
+};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/react-slick": "^0.23.13",
     "@types/uuid": "^9.0.3",
     "assert": "^2.0.0",
-    "axios": "^1.4.0",
+    "axios": "^1.7.7",
     "bootstrap": "^5.3.3",
     "buffer": "^6.0.3",
     "bufferutil": "^4.0.7",

--- a/src/app/admin-panel/contests/page.tsx
+++ b/src/app/admin-panel/contests/page.tsx
@@ -1,0 +1,381 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import {
+  Container,
+  Row,
+  Col,
+  Table,
+  Button,
+  Modal,
+  Form,
+  Spinner,
+  OverlayTrigger,
+  Tooltip,
+} from 'react-bootstrap';
+
+import useSearchParamsHook from '@/components/utils/searchParamsHook';
+import { useAuthStore } from '@/store/useStore';
+import { useRouter } from 'next/navigation';
+import { ConnectPlugWalletSlice } from '@/types/store';
+import {
+  Contest,
+  GroupedContests,
+  Match,
+} from '@/types/fantasy';
+
+import {
+  fetchMatch,
+  getContests,
+  isConnected,
+  isDev,
+} from '@/components/utils/fantasy';
+import {
+  DefaultContest,
+  EnvironmentEnum,
+  QueryParamType,
+} from '@/constant/variables';
+import AddContest from '@/components/Components/AddContest';
+import JoinContest from '@/components/Components/JoinContest';
+import { toast } from 'react-toastify';
+import logger from '@/lib/logger';
+import ContestItem from '@/components/Components/ContestItem';
+import { TEAM_CREATION_ROUTE } from '@/constant/routes';
+
+import Countdown from 'react-countdown';
+import CountdownRender from '@/components/Components/CountdownRenderer';
+import ConnectModal from '@/components/Components/ConnectModal';
+
+export default function Contests() {
+  const urlparama = useSearchParamsHook();
+  const searchParams = new URLSearchParams(urlparama);
+  const matchId = searchParams.get('matchId');
+  const type = searchParams.get('type');
+  const [match, setMatch] = useState<Match | null>(null);
+  const [timeLeft, setTimeLeft] = useState('');
+
+  const [showModal, setShowModal] = useState(false);
+  const [updateId, setUpdateId] = useState<null | string>(null);
+  const navigation = useRouter();
+  const [showConnect, setShowConnect] = useState(false);
+  const [path, setPath] = useState<string | null>(null);
+  const router = useRouter();
+  const { auth, userAuth } = useAuthStore((state) => ({
+    auth: (state as ConnectPlugWalletSlice).auth,
+    userAuth: (state as ConnectPlugWalletSlice).userAuth,
+  }));
+
+  const handleShowModal = () => {
+    setShowModal(true);
+    setUpdateId(null);
+  };
+  const handleShowUpdateModal = (id: string) => {
+    setShowModal(true);
+    setUpdateId(id);
+  };
+
+  const handleCloseModal = () => {
+    if (matchId)
+      getContests({ matchId, userAuth, actor: auth.actor, setContests });
+
+    setShowModal(false);
+    setUpdateId(null);
+  };
+
+  const [contests, setContests] = useState<Contest[] | null>(null);
+  const [selectedContest, setSelectedContest] = useState<Contest | null>(null);
+  const [groupedContests, setGroupedContests] = useState<
+    GroupedContests[] | null
+  >(null);
+
+  const [showRanking, setShowRanking] = useState(false);
+  const [showSelect, setShowSelect] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [show, setShow] = useState(false);
+
+  const handleShowRanking = (contest: Contest) => {
+    setSelectedContest(contest);
+    setShowRanking(true);
+  };
+  const handleCloseRanking = () => {
+    setShowRanking(false);
+  };
+  const handleSelectSquad = (contest: Contest) => {
+    setSelectedContest(contest);
+    setShowSelect(true);
+  };
+  const handleCloseSelect = () => {
+    setShowSelect(false);
+  };
+  let handleShowConnect = () => {
+    setShowConnect(true);
+  };
+
+  async function addDefaultContest() {
+    if (!matchId) return toast.error('No match');
+    setLoading(true);
+    try {
+      let resp = await auth.actor.addContest({ ...DefaultContest, matchId });
+      if (resp?.ok) {
+        toast.success('Default Contest added');
+        if (matchId)
+          getContests({ matchId, userAuth, actor: auth.actor, setContests });
+      } else {
+        logger(resp?.err);
+        toast.error('error while adding');
+      }
+    } catch (error) {
+      logger(error);
+    }
+    setLoading(false);
+  }
+  /**
+   * Asynchronously distributes rewards for a match.
+   *
+   * @throws {Error} If there is no match ID.
+   */
+  async function distributeReward() {
+    if (!matchId) return toast.error('No match');
+    setLoading(true);
+    try {
+      let resp = await auth.actor.distributeRewards(matchId);
+      if (resp?.ok) {
+        toast.success('Reward Distrbuted');
+      } else {
+        logger(resp?.err);
+        toast.error("something went wronge");
+      }
+    } catch (error) {
+      logger(error);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    if (!isConnected(auth.state)) return;
+    if (!matchId) {
+      getContests({ userAuth, actor: auth.actor, setGroupedContests });
+    } else {
+      getContests({ matchId, userAuth, actor: auth.actor, setContests });
+    }
+
+    if (!matchId) return;
+    fetchMatch({
+      matchId: matchId,
+      actor: auth.actor,
+      setMatch,
+    });
+  }, [auth, matchId]);
+ 
+  useEffect(() => {
+    if (isConnected(auth.state)) {
+      if (!userAuth.userPerms?.admin) {
+        navigation.replace('/');
+      }
+    }
+  }, [auth.state]);
+
+  return (
+    <>
+      {userAuth.userPerms?.admin && (
+        <Container fluid className='inner-page'>
+          <Row>
+            <Container>
+              <Row>
+                <Col xl='12' lg='12' md='12'>
+                  <div className='gray-panel'>
+                    <h4 className='animeleft d-flex justify-content-between whitecolor Nasalization fw-normal'>
+                      <span>Contests</span>
+                      <div className='d-flex gap-5'>
+                        <Button
+                          id='create_contests'
+                          onClick={handleShowModal}
+                          className='reg-btn  text-capitalize'
+                        >
+                          Create Contest
+                        </Button>
+                        <Button
+                          id='Add_Default_Contest'
+                          onClick={addDefaultContest}
+                          disabled={loading}
+                          className='reg-btn  text-capitalize'
+                        >
+                          {loading ? (
+                            <Spinner size='sm' />
+                          ) : (
+                            'Add Default Contest'
+                          )}
+                        </Button>{' '}
+                        {isDev() && (
+                          <Button
+                            id='Add_Default_Contest'
+                            onClick={() => {
+                              const matchStarted = auth.actor.testingStartMatch(
+                                matchId,
+                                5,
+                              );
+                              logger(matchStarted);
+                            }}
+                            disabled={
+                              loading   }
+                            className='reg-btn  text-capitalize'
+                          >
+                            Start match
+                          </Button>
+                        )}
+                      </div>
+                    </h4>
+
+                    <div className='spacer-30' />
+                    <h5 className='whitecolor Nasalization'>
+                      League <span> Name</span>
+                    </h5>
+                    <div className='spacer-20' />
+
+                    {contests && contests.length > 0 ? (
+                      <div className='contests_name_div'>
+                        {match && Number(match.time) > Date.now() ? (
+                          <OverlayTrigger
+                            placement='top'
+                            overlay={
+                              <Tooltip
+                                id='tooltip-top'
+                                className='Nasalization text-white'
+                              >
+                                Time{' '}
+                                <span> Remaining untill the match starts</span>
+                              </Tooltip>
+                            }
+                          >
+                            <Link
+                              href={''}
+                              className='underlined reg-btn reg-custom-btn empty text-capitalize text-white'
+                            >
+                              <Countdown
+                                date={match?.time}
+                                renderer={CountdownRender}
+                              />
+                              {/* <h6 className='timer text-white'>{timeleft}</h6> */}
+                            </Link>
+                          </OverlayTrigger>
+                        ) : (
+                          <span></span>
+                        )}
+                        <h5 className='whitecolor molde-div'>
+                          <span>
+                            {match?.homeTeam.name}
+                            &nbsp;
+                            <img
+                              src={match?.homeTeam.logo}
+                              width={30}
+                              alt='homeTeamlogo'
+                            />{' '}
+                          </span>
+                          {match && Number(match.time) < Date.now() ? (
+                            <p className='rank mx-3'>
+                              {Number(match?.homeScore)} -{' '}
+                              {Number(match?.awayScore)}{' '}
+                            </p>
+                          ) : (
+                            <p className='mt-4 mx-4 w_rank'>VS</p>
+                          )}
+                          <span>
+                            <img
+                              src={match?.awayTeam.logo}
+                              alt='awayTeamlogo'
+                              width={30}
+                            />
+                            &nbsp;{match?.awayTeam.name}{' '}
+                          </span>
+                        </h5>
+                        {match && Number(match.time) > Date.now() ? (
+                          <Link
+                            className='reg-btn trans-white mid text-capitalize btn btn-primary'
+                            href={'#'}
+                            // href={
+                            //   isConnected(auth.state)
+                            //     ? `${TEAM_CREATION_ROUTE}?matchId=${matchId}`
+                            //     : '#'
+                            // }
+                            onClick={(e) => {
+                              e.preventDefault();
+                              if (!isConnected(auth.state)) {
+                                handleShowConnect();
+
+                                setPath(
+                                  `${TEAM_CREATION_ROUTE}?matchId=${matchId}`,
+                                );
+                              } else {
+                                router.push(
+                                  `${TEAM_CREATION_ROUTE}?matchId=${matchId}`,
+                                );
+                              }
+                            }}
+                          >
+                            Create Team
+                          </Link>
+                        ) : (
+                          <span> </span>
+                        )}
+                      </div>
+                    ) : (
+                      <div className='no-contests spacer-20'>
+                        <p className='text-center text-white'>
+                          No Contest Found
+                        </p>
+                      </div>
+                    )}
+
+                    <div className='spacer-20' />
+                    <Container fluid>
+                      <Row>
+                        <Container>
+                          <Row>
+                            <Col xl='12' lg='12' md='12'>
+                              <div className='package-contest-big'>
+                                {type == QueryParamType.simple
+                                  ? contests?.map((contest) => (
+                                      
+                                      <ContestItem
+                                        timeleft={timeLeft}
+                                        handleSelectSquad={handleSelectSquad}
+                                        handleShowRanking={handleShowRanking}
+                                        contest={contest}
+                                        selectedContest={selectedContest}
+                                        match={match}
+                                        key={contest.id}
+                                        setSelectedContest={setSelectedContest}
+                                       
+                                        isAdminPannel={true}
+                                        handleShowUpdateModal={
+                                          handleShowUpdateModal
+                                        }
+                                      />
+                                    ))
+                                  : null}
+                              </div>
+                            </Col>
+                          </Row>
+                        </Container>
+                      </Row>
+                    </Container>
+                  </div>
+                </Col>
+              </Row>
+            </Container>
+          </Row>
+        </Container>
+      )}
+      <AddContest
+        showModal={showModal}
+        handleCloseModal={handleCloseModal}
+        updateId={updateId}
+        handleShowModal={handleShowModal}
+        matchId={matchId}
+      />
+
+    </>
+  );
+}

--- a/src/app/admin-panel/layout.tsx
+++ b/src/app/admin-panel/layout.tsx
@@ -1,0 +1,5 @@
+import React, { Suspense } from 'react';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>;
+}

--- a/src/app/create-team/page.tsx
+++ b/src/app/create-team/page.tsx
@@ -529,120 +529,110 @@ export default function PlayerSelection() {
   async function saveTeam(values: FormikValues) {
 
     setSaving(true);
-    setTimeout(() => {
+  
+    let allPlayers = [...selectedPlayers.all, ...selectedSubstitudePlayers.all];
+    let goalKepersPlayers = [
+      ...selectedPlayers.goalKeeper,
+      ...selectedSubstitudePlayers.goalKeeper,
+    ];
+    let midfielderPlayers = [
+      ...selectedPlayers.midfielder,
+      ...selectedSubstitudePlayers.midfielder,
+    ];
+    let forwardPlayers = [
+      ...selectedPlayers.forward,
+      ...selectedSubstitudePlayers.forward,
+    ];
+    let defenderPlayers = [
+      ...selectedPlayers.defender,
+      ...selectedSubstitudePlayers.defender,
+    ];
+
+    if (allPlayers?.length < MAX_PLAYERS) {
+      setSaving(false);
+      return toast.warning(`Please select ${MAX_PLAYERS} players`);
+    }
+
+    try {
+      let _goalkeeper = goalKepersPlayers?.map((player, index) => {
+        if (index >= teamFormation?.goalKeeper) {
+          logger({
+            index,
+            tgk: teamFormation?.goalKeeper - 1,
+            lg: index >= teamFormation?.goalKeeper - 1,
+          });
+          return [player.id, true];
+        } else {
+          return [player.id, false];
+        }
+      });
+      let _defender = defenderPlayers?.map((player, index) => {
+        if (index >= teamFormation?.defender) {
+          return [player.id, true];
+        } else {
+          return [player.id, false];
+        }
+      });
+      let _midfielder = midfielderPlayers?.map((player, index) => {
+        if (index >= teamFormation?.midfielder) {
+          return [player.id, true];
+        } else {
+          return [player.id, false];
+        }
+      });
+      let _forward = forwardPlayers.map((player, index) => {
+        if (index >= teamFormation?.forward) {
+          return [player.id, true];
+        } else {
+          return [player.id, false];
+        }
+      });
+      let newPlayers = [
+        ..._goalkeeper,
+        ..._defender,
+        ..._midfielder,
+        ..._forward,
+      ];
+      let formationString = `${teamFormation?.defender}-${teamFormation?.midfielder}-${teamFormation?.forward}`;
+      let squad = {
+        name: values.name,
+        matchId: matchId,
+        cap: '',
+        viceCap: '',
+        players: newPlayers,
+        formation: `${teamFormation?.defender}-${teamFormation?.midfielder}-${teamFormation?.forward}`,
+      };
+      if (squadId) {
+        const addedSquad = await auth.actor.updatePlayerSquad(squadId, squad);
+        if (addedSquad?.ok) {
+          toast.success('Team Updated');
+          resetPlayers(true);
+          router.push(
+            `${MATCH_CONTEST_ROUTE}matchId=${matchId}&type=${QueryParamType.simple}`,
+          );
+        } else if (addedSquad?.err) {
+          toast.error(addedSquad?.err);
+        }
+
+        logger(addedSquad, 'sSquad updated');
+      } else {
+        const addedSquad = await auth.actor.addPlayerSquad(squad);
+        if (addedSquad?.ok) {
+          toast.success(addedSquad?.ok);
+          resetPlayers(true);
+          router.push(
+            `${MATCH_CONTEST_ROUTE}matchId=${matchId}&type=${QueryParamType.simple}`,
+          );
+        } else if (addedSquad?.err) {
+          toast.error(addedSquad?.err);
+        }
+
+        logger(addedSquad, 's:::::');
+      }
+    } catch (error) {
+      console.error(error);
+    }
     setSaving(false);
-    toast.success("Team created successfully.")
-    resetPlayers(true);
-    router.push(MATCHES_ROUTE);
-    }, 2000);
-    // let allPlayers = [...selectedPlayers.all, ...selectedSubstitudePlayers.all];
-    // let goalKepersPlayers = [
-    //   ...selectedPlayers.goalKeeper,
-    //   ...selectedSubstitudePlayers.goalKeeper,
-    // ];
-    // let midfielderPlayers = [
-    //   ...selectedPlayers.midfielder,
-    //   ...selectedSubstitudePlayers.midfielder,
-    // ];
-    // let forwardPlayers = [
-    //   ...selectedPlayers.forward,
-    //   ...selectedSubstitudePlayers.forward,
-    // ];
-    // let defenderPlayers = [
-    //   ...selectedPlayers.defender,
-    //   ...selectedSubstitudePlayers.defender,
-    // ];
-
-    // if (allPlayers?.length < MAX_PLAYERS) {
-    //   setSaving(false);
-    //   return toast.warning(`Please select ${MAX_PLAYERS} players`);
-    // }
-
-    // try {
-    //   let _goalkeeper = goalKepersPlayers?.map((player, index) => {
-    //     if (index >= teamFormation?.goalKeeper) {
-    //       logger({
-    //         index,
-    //         tgk: teamFormation?.goalKeeper - 1,
-    //         lg: index >= teamFormation?.goalKeeper - 1,
-    //       });
-    //       return [player.id, true];
-    //     } else {
-    //       return [player.id, false];
-    //     }
-    //   });
-    //   let _defender = defenderPlayers?.map((player, index) => {
-    //     if (index >= teamFormation?.defender) {
-    //       return [player.id, true];
-    //     } else {
-    //       return [player.id, false];
-    //     }
-    //   });
-    //   let _midfielder = midfielderPlayers?.map((player, index) => {
-    //     if (index >= teamFormation?.midfielder) {
-    //       return [player.id, true];
-    //     } else {
-    //       return [player.id, false];
-    //     }
-    //   });
-    //   let _forward = forwardPlayers.map((player, index) => {
-    //     if (index >= teamFormation?.forward) {
-    //       return [player.id, true];
-    //     } else {
-    //       return [player.id, false];
-    //     }
-    //   });
-    //   let newPlayers = [
-    //     ..._goalkeeper,
-    //     ..._defender,
-    //     ..._midfielder,
-    //     ..._forward,
-    //   ];
-    //   let formationString = `${teamFormation?.defender}-${teamFormation?.midfielder}-${teamFormation?.forward}`;
-    //   let squad = {
-    //     name: values.name,
-    //     matchId: matchId,
-    //     cap: '',
-    //     viceCap: '',
-    //     players: newPlayers,
-    //     formation: `${teamFormation?.defender}-${teamFormation?.midfielder}-${teamFormation?.forward}`,
-    //   };
-    //   if (squadId) {
-    //     const addedSquad = await auth.actor.updatePlayerSquad(squadId, squad);
-    //     if (addedSquad?.ok) {
-    //       toast.success('Team Updated');
-    //       resetPlayers(true);
-    //       router.push(
-    //         `${MATCH_CONTEST_ROUTE}matchId=${matchId}&type=${QueryParamType.simple}`,
-    //       );
-    //     } else if (addedSquad?.err) {
-    //       toast.error(addedSquad?.err);
-    //     }
-    //     // toast.success('Team Updated');
-    //     // router.push(
-    //     //   `${TEAMS_ROUTE}?matchId=${matchId}&type=${QueryParamType.simple}`,
-    //     // );
-    //     // resetPlayers(true);
-
-    //     logger(addedSquad, 'sSquad updated');
-    //   } else {
-    //     const addedSquad = await auth.actor.addPlayerSquad(squad);
-    //     if (addedSquad?.ok) {
-    //       toast.success(addedSquad?.ok);
-    //       resetPlayers(true);
-    //       router.push(
-    //         `${MATCH_CONTEST_ROUTE}matchId=${matchId}&type=${QueryParamType.simple}`,
-    //       );
-    //     } else if (addedSquad?.err) {
-    //       toast.error(addedSquad?.err);
-    //     }
-
-    //     logger(addedSquad, 's:::::');
-    //   }
-    // } catch (error) {
-    //   console.error(error);
-    // }
-    // setSaving(false);
   }
   /**
    * The function to take the name of the team in the values params and adds the team with the selected players to the canister

--- a/src/app/matches/contest/page.tsx
+++ b/src/app/matches/contest/page.tsx
@@ -1,0 +1,407 @@
+'use client';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import {
+  Container,
+  Row,
+  Col,
+  Table,
+  Button,
+  Modal,
+  Form,
+  Tabs,
+  Tab,
+  Spinner,
+  OverlayTrigger,
+  Tooltip,
+} from 'react-bootstrap';
+import useSearchParamsHook from '@/components/utils/searchParamsHook';
+import tethericon from '@/assets/images/icons/tether-icon.png';
+import { useAuthStore } from '@/store/useStore';
+import { useRouter } from 'next/navigation';
+import { ConnectPlugWalletSlice } from '@/types/store';
+import {
+  Contest,
+  ContestType,
+  LoadingState,
+  Match,
+  MatchesCountType,
+} from '@/types/fantasy';
+import {
+  fetchMatch,
+  getFilterdContests,
+  isConnected,
+  getIcpRate,
+} from '@/components/utils/fantasy';
+
+import {
+  DEFAULT_MATCH_STATUS,
+  Intervals,
+  MATCHES_ITEMSPERPAGE,
+  MatchStatusNames,
+  MatchStatuses,
+  QURIES,
+  QueryParamType,
+} from '@/constant/variables';
+import ContestItem from '@/components/Components/ContestItem';
+import Countdown from 'react-countdown';
+import CountdownRender from '@/components/Components/CountdownRenderer';
+import { TEAM_CREATION_ROUTE } from '@/constant/routes';
+import ConnectModal from '@/components/Components/ConnectModal';
+
+export default function Contests() {
+  const urlparama = useSearchParamsHook();
+  const searchParams = new URLSearchParams(urlparama);
+  const matchId = searchParams.get('matchId');
+  const type = searchParams.get('type');
+  const [contests, setContests] = useState<Contest[] | null>(null);
+  const [selectedContest, setSelectedContest] = useState<Contest | null>(null);
+  const [match, setMatch] = useState<Match | null>(null);
+  const [showRanking, setShowRanking] = useState(false);
+  const [showSelect, setShowSelect] = useState(false);
+  const [show, setShow] = useState(false);
+  const [timeLeft, setTimeLeft] = useState('');
+  const router = useRouter();
+  const [matchTab, setMatchTab] = useState<string>(DEFAULT_MATCH_STATUS);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [icpRate, setIcpRate] = useState(0);
+  const [showConnect, setShowConnect] = useState(false);
+  const [path, setPath] = useState<string | null>(null);
+
+  const { auth, userAuth } = useAuthStore((state) => ({
+    auth: (state as ConnectPlugWalletSlice).auth,
+    userAuth: (state as ConnectPlugWalletSlice).userAuth,
+  }));
+  const matchProps = {
+    status: DEFAULT_MATCH_STATUS,
+    page: 0,
+    search: '',
+    limit: MATCHES_ITEMSPERPAGE,
+  };
+  const [loading, setLoadingState] = useState<LoadingState>({
+    upcoming: true,
+    ongoing: true,
+    finished: true,
+  });
+  const [pageCount, setPageCount] = useState<MatchesCountType>({
+    upcoming: 1,
+    ongoing: 1,
+    finished: 1,
+  });
+  const [offset, setOffset] = useState<MatchesCountType>({
+    upcoming: 0,
+    ongoing: 0,
+    finished: 0,
+  });
+  const [groupedContests, setGroupedContests] = useState<ContestType>({
+    upcoming: null,
+    ongoing: null,
+    finished: null,
+  });
+
+  /**
+   * Fetches contests based on a given status and other match properties.
+   *
+   * @async
+   * @function getStatusContests
+   * @param status - The status of the contests to filter by. Can be a string representing the status or null.
+   * @returns A promise that resolves when the contests are fetched and state is updated.
+   */
+  async function getStatusContests(status: string | null, loader: boolean) {
+    if (matchId && matchId != null)
+      await getFilterdContests(
+        matchId,
+        auth.actor,
+        userAuth,
+        null,
+        { ...matchProps, status, page: 0 },
+        setContests,
+        setPageCount,
+        loader ? setLoadingState : () => {},
+      );
+  }
+
+  /**
+   * Handle the selection of a contest.
+   *
+   * @param {Contest} contest - The selected contest
+   */
+  const handleSelectContest = (contest: Contest) => {
+    setSelectedContest(contest);
+    fetchMatch({
+      matchId: contest.matchId,
+      actor: auth.actor,
+      setMatch,
+    });
+  };
+  /**
+   * Handles showing the ranking for a specific contest.
+   *
+   * @param {Contest} contest - The contest for which the ranking is to be shown.
+   * @return {void} No return value.
+   */
+  const handleShowRanking = (contest: Contest) => {
+    handleSelectContest(contest);
+    setShowRanking(true);
+  };
+  /**
+   * Closes the ranking and resets the match state.
+   *
+   * @return {void} No return value.
+   */
+  const handleCloseRanking = () => {
+    // setMatch(null);
+    setShowRanking(false);
+  };
+  /**
+   * Handles the selection of a squad.
+   *
+   * @param {Contest} contest - The contest to select.
+   * @return {void}
+   */
+  const handleSelectSquad = (contest: Contest) => {
+    handleSelectContest(contest);
+    setShowSelect(true);
+  };
+  /**
+   * A function to handle closing the selection and resetting the match.
+   *
+   * @return {void} No return value
+   */
+  const handleCloseSelect = () => {
+    setMatch(null);
+    setShowSelect(false);
+  };
+  let handleShowConnect = () => {
+    setShowConnect(true);
+  };
+  function handleHideConnect() {
+    setShowConnect(false);
+  }
+  const handleClose = () => setShow(false);
+  /**
+   * clickRef use as a callback route user connection modal should route after connection
+   */
+  let clickRef = () => {
+    if (path) {
+      router.push(path);
+    }
+  };
+  useEffect(() => {
+    // if (!isConnected(auth.state)) return;
+    if (!auth.actor) return;
+    let tempTab = searchParams.get(QURIES.matchTab);
+    if (tempTab) setMatchTab(tempTab);
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    // Initial fetch
+    getStatusContests(tempTab ?? DEFAULT_MATCH_STATUS, true);
+
+    // Set up new interval
+    intervalRef.current = setInterval(() => {
+      if (matchId) {
+        fetchMatch({
+          matchId: matchId,
+          actor: auth.actor,
+          setMatch,
+        });
+      }
+      getStatusContests(tempTab ?? DEFAULT_MATCH_STATUS, false);
+    }, Intervals.contest);
+    // Initial fetch
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [auth, matchId]);
+  useEffect(() => {
+    if (!matchId || !auth.actor) return;
+    fetchMatch({
+      matchId: matchId,
+      actor: auth.actor,
+      setMatch,
+    });
+  }, [auth, matchId]);
+  let getLatestIcpRate = async () => {
+    let rate = await getIcpRate();
+    setIcpRate(rate);
+  };
+  useEffect(() => {
+    getLatestIcpRate();
+  }, []);
+  return (
+    <>
+      <Container fluid className='inner-page'>
+        <Row>
+          <Container>
+            <Row>
+              <Col xl='12' lg='12' md='12'>
+                <div className='gray-panel web-view-trans'>
+                  <h4 className='animeleft whitecolor tablet-view-none Nasalization fw-normal'>
+                    <span>Contests</span>
+                  </h4>
+                  <small className='text-white tablet-view-none Nasalization'>
+                    {' '}
+                    Create team and join contest
+                  </small>
+                  <div className='spacer-30 tablet-view-none' />
+
+                  <div className='spacer-10 tablet-view-none' />
+                  {type == QueryParamType.simple ? (
+                    loading.upcoming ? (
+                      <p className='text-center'>
+                        <Spinner />
+                      </p>
+                    ) : contests && contests?.length != 0 ? (
+                      <>
+                        <div className='contests_name_div nam'>
+                          {match && Number(match.time) > Date.now() ? (
+                            <OverlayTrigger
+                              placement='top'
+                              overlay={
+                                <Tooltip
+                                  id='tooltip-top'
+                                  className='Nasalization text-white'
+                                >
+                                  Time{' '}
+                                  <span>
+                                    {' '}
+                                    Remaining untill the match starts
+                                  </span>
+                                </Tooltip>
+                              }
+                            >
+                              <Link
+                                href={''}
+                                className='underlined  tablet-view-none reg-btn reg-custom-btn empty text-capitalize text-white'
+                              >
+                                <Countdown
+                                  date={match?.time}
+                                  renderer={CountdownRender}
+                                />
+                                {/* <h6 className='timer text-white'>{timeleft}</h6> */}
+                              </Link>
+                            </OverlayTrigger>
+                          ) : (
+                            <span></span>
+                          )}
+                          <h5 className='whitecolor molde-div'>
+                            <span>
+                              {match?.homeTeam.name}
+                              &nbsp;
+                              <img
+                                src={match?.homeTeam.logo}
+                                width={30}
+                                alt='homeTeamlogo'
+                              />{' '}
+                            </span>
+                            {match && Number(match.time) < Date.now() ? (
+                              <p className='rank mx-3'>
+                                {Number(match?.homeScore)} -{' '}
+                                {Number(match?.awayScore)}{' '}
+                              </p>
+                            ) : (
+                              <p className='mt-4 mx-4 w_rank'>VS</p>
+                            )}
+                            <span>
+                              <img
+                                src={match?.awayTeam.logo}
+                                alt='awayTeamlogo'
+                                width={30}
+                              />
+                              &nbsp;{match?.awayTeam.name}{' '}
+                            </span>
+                          </h5>
+                          {match && Number(match.time) > Date.now() ? (
+                            <Link
+                              className='reg-btn trans-white mid text-capitalize btn btn-primary tablet-view-none'
+                              href={'#'}
+                              // href={
+                              //   isConnected(auth.state)
+                              //     ? `${TEAM_CREATION_ROUTE}?matchId=${matchId}`
+                              //     : '#'
+                              // }
+                              onClick={(e) => {
+                                e.preventDefault();
+                                if (!isConnected(auth.state)) {
+                                  handleShowConnect();
+
+                                  setPath(
+                                    `${TEAM_CREATION_ROUTE}?matchId=${matchId}`,
+                                  );
+                                } else {
+                                  router.push(
+                                    `${TEAM_CREATION_ROUTE}?matchId=${matchId}`,
+                                  );
+                                }
+                              }}
+                            >
+                              Create Team
+                            </Link>
+                          ) : (
+                            <span></span>
+                          )}
+                        </div>
+
+                        {/* {contests?.map((contest: Contest) => (
+                          <ContestRow
+                            timeleft={timeLeft}
+                            handleSelectSquad={handleSelectSquad}
+                            handleShowRanking={handleShowRanking}
+                            contest={contest}
+                            selectedContest={selectedContest}
+                            match={match}
+                            key={contest.id}
+                            setSelectedContest={setSelectedContest}
+                          />
+                        ))} */}
+                        <Container fluid>
+                          <Row>
+                            <Container>
+                              <Row>
+                                <Col xl='12' lg='12' md='12'>
+                                  <div className='spacer-50' />
+                                  <div className='package-contest-big'>
+                                    {contests?.map((contest: Contest) => (
+                                      <ContestItem
+                                        timeleft={timeLeft}
+                                        handleSelectSquad={handleSelectSquad}
+                                        handleShowRanking={handleShowRanking}
+                                        contest={contest}
+                                        selectedContest={selectedContest}
+                                        match={match}
+                                        key={contest.id}
+                                        setSelectedContest={setSelectedContest}
+                                        icpRate={icpRate}
+                                      />
+                                    ))}
+                                  </div>
+                                </Col>
+                              </Row>
+                            </Container>
+                          </Row>
+                        </Container>
+                      </>
+                    ) : (
+                      <p className='text-center text-white'>No Contest Found</p>
+                    )
+                  ) : null}
+                  {/* Contest Post */}
+                </div>
+              </Col>
+            </Row>
+          </Container>
+        </Row>
+      </Container>
+      <ConnectModal
+        show={showConnect}
+        hideModal={handleHideConnect}
+        callBackfn={clickRef}
+      />
+    </>
+  );
+}

--- a/src/components/Components/AddContest.tsx
+++ b/src/components/Components/AddContest.tsx
@@ -1,0 +1,263 @@
+'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import { date, object, string, number, array } from 'yup';
+import { Spinner, Modal, Form, Button } from 'react-bootstrap';
+import {
+  ErrorMessage,
+  Field,
+  Formik,
+  Form as FormikForm,
+  FieldArray,
+} from 'formik';
+import {
+  MAX_NAME_CHARACTERS,
+  MIN_NAME_CHARACTERS,
+  Messages,
+  ONLY_ALPHABET,
+  Validations,
+} from '@/constant/validations';
+import logger from '@/lib/logger';
+import { useAuthStore } from '@/store/useStore';
+import { ConnectPlugWalletSlice } from '@/types/store';
+import { toast } from 'react-toastify';
+import { getContest } from '../utils/fantasy';
+import { Contest } from '@/types/fantasy';
+import Tippy from '@tippyjs/react';
+
+interface Props {
+  matchId: string | null;
+  showModal: boolean;
+  updateId: string | null;
+  handleCloseModal: () => void;
+  handleShowModal: () => void;
+}
+const AddContest = ({
+  matchId,
+  handleCloseModal,
+  handleShowModal,
+  showModal,
+  updateId,
+}: Props) => {
+  const [saving, setSaving] = useState(false);
+  const [oldContest, setOldContest] = useState<Contest | null>(null);
+  const { auth, userAuth } = useAuthStore((state) => ({
+    auth: (state as ConnectPlugWalletSlice).auth,
+    userAuth: (state as ConnectPlugWalletSlice).userAuth,
+  }));
+  const initialContest = {
+    name: oldContest?.name ?? '',
+    slots: oldContest?.slots ?? '',
+    minCap: oldContest?.minCap ?? '',
+    teamsPerUser: oldContest?.teamsPerUser ?? '',
+    rules: oldContest?.rules ?? '',
+    // maxCap: '',
+  };
+  const heading = updateId ? 'Update Contest' : 'Add Contest';
+  const button = updateId ? 'Update' : 'Add';
+
+  const contestSchema = object().shape({
+    name: string()
+      .required(Messages.contest.name.min)
+      .max(Validations.contests.name.max, Messages.contest.name.min)
+      .min(MIN_NAME_CHARACTERS, Messages.contest.name.max),
+    slots: number()
+      .required(Messages.contest.slots.req)
+      .min(Validations.contests.slots.min, Messages.contest.slots.min),
+    teamsPerUser: number()
+      .required(Messages.contest.teamsPerUser.req)
+      .min(
+        Validations.contests.teamsPerUser.min,
+        Messages.contest.teamsPerUser.min,
+      ),
+    rules: string().required(Messages.contest.rules.req),
+
+  });
+  async function handleContest(values: any, actions: any) {
+    try {
+      setSaving(true);
+
+
+      const contest = {
+        name: values.name,
+        slots: values.slots,
+        teamsPerUser: values.teamsPerUser,
+        rules: values.rules,
+        matchId,
+        minCap: 0,
+        maxCap: 0,
+        providerId: '0'
+      };
+      logger(contest, 'foormm gothca');
+      let respContest;
+      if (updateId) {
+        respContest = await auth.actor.updateContest(contest, updateId);
+      } else {
+        respContest = await auth.actor.addContest(contest);
+      }
+      logger({ contest, updateId, respContest }, 'foormm gothca');
+      if (respContest?.ok) {
+        toast.success(respContest?.ok);
+        handleCloseModal();
+      } else {
+        toast.error(respContest?.err);
+      }
+      logger(respContest, 'we did this k?');
+    } catch (error) {
+      toast.error('Error');
+      logger(error, 'error adding contest');
+    }
+    setSaving(false);
+  }
+
+  useEffect(() => {
+    logger({ updateId }, 'foormm gothca');
+
+    if (updateId) {
+      getContest(auth.actor, updateId, setOldContest);
+    } else {
+      setOldContest(null);
+    }
+  }, [showModal, updateId]);
+  return (
+    <Modal show={showModal} centered className='mt-5' onHide={handleCloseModal}>
+      <Modal.Body className='mt-5'>
+        <h5 className='text-center'>{button} Contest</h5>
+        <Formik
+          initialValues={initialContest}
+          validationSchema={contestSchema}
+          valid
+          enableReinitialize
+          onSubmit={async (values: any, actions) => {
+            handleContest(values, actions);
+            // await newContest(values);
+          }}
+        >
+          {({
+            errors,
+            touched,
+            handleChange,
+            handleBlur,
+            isValid,
+            dirty,
+            values,
+          }) => (
+            <FormikForm className='flex w-full flex-col items-center justify-center'>
+              <Field name='name'>
+                {({ field, formProps }: any) => (
+                  <Form.Group className='mb-2'>
+                    <Form.Label>Name</Form.Label>
+                    <Form.Control
+                      type='text'
+                      placeholder={'Enter Contest Name'}
+                      value={field.value}
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      onInput={handleChange}
+                      name='name'
+                    />
+                  </Form.Group>
+                )}
+              </Field>
+              <div className='text-danger mb-2'>
+                <ErrorMessage className='Mui-err' name='name' component='div' />
+              </div>
+              <Field name='slots'>
+                {({ field, formProps }: any) => (
+                  <Form.Group className='mb-2'>
+                    <Form.Label>Slots</Form.Label>
+                    <Form.Control
+                      type='number'
+                      placeholder={'Enter the amount of slots'}
+                      value={field.value}
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      onInput={handleChange}
+                      name='slots'
+                    />
+                  </Form.Group>
+                )}
+              </Field>
+              <div className='text-danger mb-2'>
+                <ErrorMessage
+                  className='Mui-err'
+                  name='slots'
+                  component='div'
+                />
+              </div>
+
+              <Field name='teamsPerUser'>
+                {({ field, formProps }: any) => (
+                  <Form.Group className='mb-2'>
+                    <Form.Label>Teams Per User</Form.Label>
+                    <Form.Control
+                      type='number'
+                      placeholder={'Enter Teams Per User'}
+                      value={field.value}
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      onInput={handleChange}
+                      name='teamsPerUser'
+                    />
+                  </Form.Group>
+                )}
+              </Field>
+              <div className='text-danger mb-2'>
+                <ErrorMessage
+                  className='Mui-err'
+                  name='teamsPerUser'
+                  component='div'
+                />
+              </div>
+              <Field name='rules'>
+                {({ field, formProps }: any) => (
+                  <Form.Group className='mb-2'>
+                    <Tippy
+                      content={<span>Separate each rule with a "," comma</span>}
+                      className='dark-tippy'
+                    >
+                      <Form.Label>
+                        Rules <i className='fa fa-info-circle fa-sm '></i>
+                      </Form.Label>
+                    </Tippy>
+                    <Form.Control
+                      type='text'
+                      as='textarea'
+                      className='control-area'
+                      placeholder={'Enter Contest Rules'}
+                      value={field.value}
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      onInput={handleChange}
+                      name='rules'
+                    />
+                  </Form.Group>
+                )}
+              </Field>
+              <div className='text-danger mb-2'>
+                <ErrorMessage
+                  className='Mui-err'
+                  name='rules'
+                  component='div'
+                />
+              </div>
+            
+
+              <div className='d-flex justify-content-end gap-4 mt-3'>
+                <Button
+                  className='reg-btn'
+                  disabled={saving}
+                  type='submit'
+                  id='submittingBtn'
+                >
+                  {saving ? <Spinner size='sm' /> : button}
+                </Button>
+              </div>
+            </FormikForm>
+          )}
+        </Formik>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default AddContest;

--- a/src/components/Components/Calender.tsx
+++ b/src/components/Components/Calender.tsx
@@ -1,0 +1,37 @@
+'use client';
+import React, { useState } from 'react';
+import { SlCalender } from 'react-icons/sl';
+import Calendar from 'react-calendar';
+
+type ValuePiece = Date | null;
+
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+
+const Calender_ = () => {
+  const [showCalendar, setShowCalendar] = useState(false);
+  const [value, onChange] = useState<Value>(new Date());
+  const toggleCalendar = () => {
+    setShowCalendar(!showCalendar);
+  };
+  return (
+    <div className='mt-5'>
+      <div
+        className='mt-5'
+        style={{ display: 'inline-block', cursor: 'pointer' }}
+      >
+        <SlCalender
+          size={30}
+          className='mt-5 drop-shadow-glow animate-flicker text-white'
+          onClick={toggleCalendar}
+        />
+      </div>
+      {showCalendar && (
+        <div>
+          <Calendar onChange={onChange} value={value} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Calender_;

--- a/src/components/Components/CalenderSlider.tsx
+++ b/src/components/Components/CalenderSlider.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { use, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { use, useEffect, useRef, useState } from 'react';
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
 import { Container, Row, Col } from 'react-bootstrap';
@@ -8,10 +8,8 @@ import useSearchParamsHook from '@/components/utils/searchParamsHook';
 import { QURIES } from '@/constant/variables';
 export default function CarouselSlider({
   getSelectedDate,
-  myuseRef
 }: {
   getSelectedDate: any;
-  myuseRef : any;
 }) {
   interface DateInfo {
     dates: string;
@@ -101,23 +99,7 @@ export default function CarouselSlider({
       dateInMiliseconds:timeInMiliseconds,
     };
   }
-  function updateActiveIndex() {
-    const currentDefaultDate = new Date().setHours(0, 0, 0, 0);
-    if (slides && slides.length > 0) {
-      const defaultIndex = slides.findIndex(
-        (slide) => slide.dateInMiliseconds === currentDefaultDate
-      );
-      if (defaultIndex !== -1) {
-        carouselRef?.current.goToSlide(defaultIndex + 5);
-        if (defaultIndex !== activeIndex) {
-          getSelectedDate(slides[defaultIndex].dateInMiliseconds);
-        }
-      }
-    }
-  }
-  useImperativeHandle(myuseRef, () => ({   // Expose the childMethod to parent
-    updateActiveIndex,
-  }));
+
   useEffect(() => {
     let timeoutId = setTimeout(() => {
       if (carouselRef?.current) {

--- a/src/components/Components/ContestItem.tsx
+++ b/src/components/Components/ContestItem.tsx
@@ -1,0 +1,273 @@
+'use client';
+import Image from 'next/image';
+import React, { useEffect, useState } from 'react';
+import { Button, Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Contest, Match } from '@/types/fantasy';
+import Link from 'next/link';
+import useSearchParamsHook from '../utils/searchParamsHook';
+import { TEAM_CREATION_ROUTE } from '@/constant/routes';
+import Countdown, { CountdownRenderProps } from 'react-countdown';
+import { date } from 'yup';
+import {
+  copyId,
+  getPackage,
+  getPackageIcon,
+  isConnected,
+} from '../utils/fantasy';
+import ConnectModal from './ConnectModal';
+import { useAuthStore } from '@/store/useStore';
+import { ConnectPlugWalletSlice } from '@/types/store';
+import { ContestInfoType } from '@/constant/variables';
+import logger from '@/lib/logger';
+import { useRouter } from 'next/navigation';
+import Tippy from '@tippyjs/react';
+import CupSvg from '@/assets/images/icons/icon-trophy.png';
+import GiftSvg from '@/assets/images/icons/icon-gold-medal.png';
+import rulebook from '@/assets/images/icons/icon-book.png';
+import JoinContest from '@/components/Components/JoinContest';
+
+import coinicon from '@/assets/images/icons/coin-icon.png';
+import tethericon from '@/assets/images/icons/tether-icon.png';
+import CountdownRender from './CountdownRenderer';
+import PrincipalSvg from '../Icons/PrincipalSvg';
+
+interface Props {
+  contest: Contest;
+  timeleft?: string;
+  handleSelectSquad: (contest: Contest) => void;
+  handleShowRanking: (contest: Contest) => void;
+  selectedContest?: Contest | null;
+  match?: Match | null;
+  handleShowUpdateModal?: (contest: string) => void;
+  setSelectedContest?: any;
+  isDashboard?: boolean;
+  icpRate?: number;
+  isAdminPannel?: boolean;
+}
+function ContestItem({
+  contest,
+  timeleft,
+  handleSelectSquad,
+  handleShowRanking,
+  selectedContest,
+  match,
+  handleShowUpdateModal,
+  setSelectedContest,
+  isDashboard,
+  icpRate,
+  isAdminPannel,
+}: Props) {
+  const [showConnect, setShowConnect] = useState(false);
+  const [showROI, setShowROI] = useState(false);
+  const urlparama = useSearchParamsHook();
+  const [slotsLeft, setSlotsLeft] = useState(contest.slotsLeft);
+  const [showInfo, setShowInfo] = useState(false);
+  const [modalText, setModalText] = useState<string[]>([]);
+  const [showJoin, setShowJoin] = useState(false);
+  const [modalType, setModalType] = useState<ContestInfoType>(
+    ContestInfoType.rules,
+  );
+  const [contestInfo, setContestInfo] = useState({
+    entryFee: 0,
+    totalparticipants: 0,
+  });
+  const [path, setPath] = useState<string | null>(null);
+
+  const searchParams = new URLSearchParams(urlparama);
+  const matchId = searchParams.get('matchId');
+  let router = useRouter();
+  const { auth, userAuth } = useAuthStore((state) => ({
+    auth: (state as ConnectPlugWalletSlice).auth,
+    userAuth: (state as ConnectPlugWalletSlice).userAuth,
+  }));
+
+
+  /**
+   * Decreases the number of slots left.
+   *
+   * @return {void}
+   */
+  function decreaseSlots() {
+    setSlotsLeft((prev) => prev - 1);
+  }
+
+  const hideInfo = () => setShowInfo(false);
+  function handleShowConnect() {
+    setShowConnect(true);
+  }
+  /**
+   * clickRef use as a callback route user connection modal should route after connection
+   */
+  let clickRef = () => {
+    if (path) {
+      router.push(path);
+    }
+  };
+  function handleHideConnect() {
+    setShowConnect(false);
+  }
+  useEffect(() => {
+    var matchId = searchParams.get('matchId');
+    handleSelectSquad(contest);
+  }, [showJoin]);
+  useEffect(() => {
+    setSlotsLeft(contest?.slotsLeft);
+  }, [contest?.slotsLeft]);
+  logger(contest, 'agfkjhgsajkfdsadfsadfsf');
+  return (
+    <>
+      <div className={`package-contest-post-main ${getPackage(contest.name)}`}>
+        <div className='package-contest-post'>
+          <div className='package-contest-post-inner'>
+            <div className='contest-info'>
+       
+              {contest.name}
+              {isAdminPannel &&  <span className='copytbn' onClick={()=>{
+                copyId(contest.id,"Contest Id")
+              }}>
+              <PrincipalSvg />
+              </span>}
+            </div>
+            <div className='mobile-view-contest-btn'>
+            {match && Number(match.time) > Date.now() ? (
+                            <OverlayTrigger
+                              placement='top'
+                              overlay={
+                                <Tooltip
+                                  id='tooltip-top'
+                                  className='Nasalization text-white'
+                                >
+                                  Time{' '}
+                                  <span>
+                                    {' '}
+                                    Remaining untill the match starts
+                                  </span>
+                                </Tooltip>
+                              }
+                            >
+                                <h6 className=''>Starts In <span><Countdown
+                                  date={match?.time}
+                                  renderer={CountdownRender}
+                                /></span></h6>
+                            </OverlayTrigger>
+                          ) : (
+                            <span></span>
+                          )}
+             
+
+
+                                 {match && Number(match.time) > Date.now() ? (
+                            <Link
+                              className='reg-btn trans-white mid text-capitalize'
+                              href={'#'}
+                              // href={
+                              //   isConnected(auth.state)
+                              //     ? `${TEAM_CREATION_ROUTE}?matchId=${matchId}`
+                              //     : '#'
+                              // }
+                              onClick={(e) => {
+                                e.preventDefault();
+                                if (!isConnected(auth.state)) {
+                                  handleShowConnect();
+
+                                  setPath(
+                                    `${TEAM_CREATION_ROUTE}?matchId=${matchId}`,
+                                  );
+                                } else {
+                                  router.push(
+                                    `${TEAM_CREATION_ROUTE}?matchId=${matchId}`,
+                                  );
+                                }
+                              }}
+                            >
+                              Create Team
+                            </Link>
+                          ) : (
+                            <span></span>
+                          )}
+            </div>
+            <div className='post-heading-info'>
+              <div className='img-pnl'>
+                <Image className='small' src={coinicon} alt='img' />
+                <Image src={tethericon} alt='img' />
+              </div>
+              <div className='txt-pnl'>
+                <h6>{contest.name}</h6>
+               
+              </div>
+            </div>
+            <ul className='calculate-list'>
+            
+              <li>
+                <p>Participants</p>
+                <p>{contest.slotsUsed}</p>
+              </li>
+             
+            </ul>
+           
+             
+
+            {isAdminPannel ? (
+              <>
+                {handleShowUpdateModal && (
+                  <Button
+                    onClick={() => {
+                      // setSelectedContest(contest)
+                      handleShowUpdateModal(contest.id);
+                    }}
+                    className='reg-btn'
+                  >
+                    Edit Contest
+                  </Button>
+                )}
+                <Button
+                  className=' reg-btn trans-white mid text-capitalize mt-3'
+                  onClick={() => handleShowRanking(contest)}
+                  id='view_rankings_btn'
+                >
+                  View Ranking
+                </Button>{' '}
+              </>
+            ) : Number(match?.time) > Date.now() ? (
+              <Button  className='reg-btn'>
+                Join Contest
+              </Button>
+            ) : (
+              <Button
+                className=' reg-btn trans-white mid text-capitalize'
+                onClick={() => handleShowRanking(contest)}
+                id='view_rankings_btn'
+              >
+                View Ranking
+              </Button>
+            )}
+
+            {!isAdminPannel && (
+              <JoinContest
+              
+                teamsPerUser={contest.teamsPerUser}
+                contestId={contest?.id}
+                matchId={contest?.matchId}
+                match={match ?? null}
+                decreaseSlots={decreaseSlots}
+                contestPage={true}
+                updateSquad={showJoin}
+                contestName={contest.name}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+
+      <ConnectModal
+        show={showConnect}
+        hideModal={handleHideConnect}
+        callBackfn={clickRef}
+      />
+    
+     
+    </>
+  );
+}
+
+export default ContestItem;

--- a/src/components/Components/CountdownRenderer.tsx
+++ b/src/components/Components/CountdownRenderer.tsx
@@ -1,0 +1,22 @@
+import { CountdownRenderProps } from 'react-countdown';
+
+const CountdownRender = ({
+  hours,
+  days,
+  minutes,
+  seconds,
+  completed,
+}: CountdownRenderProps) => {
+  if (completed) {
+    // Render a completed state
+    return null;
+  } else {
+    // Render a countdown
+    return (
+      <span className='ms-2'>
+        {days}:{hours}:{minutes}:{seconds}
+      </span>
+    );
+  }
+};
+export default CountdownRender;

--- a/src/components/Components/DashboardTable.tsx
+++ b/src/components/Components/DashboardTable.tsx
@@ -1,0 +1,199 @@
+
+import {
+  JoinContestText,
+  MatchStatusNames,
+  QueryParamType,
+  QURIES,
+} from '@/constant/variables';
+import {
+  Contest,
+  DetailedMatchContest,
+  Match,
+  PlayerSquad,
+} from '@/types/fantasy';
+import Link from 'next/link';
+import React, { useEffect, useState } from 'react';
+import { Button, Table } from 'react-bootstrap';
+import BeatLoader from 'react-spinners/BeatLoader';
+import { getTimeZone,  isInPast } from '../utils/fantasy';
+import logger from '@/lib/logger';
+import { GAS_FEE } from '@/constant/fantasticonst';
+import { Auth } from '@/types/store';
+import { toast } from 'react-toastify';
+import TeamRow from './TeamRow';
+import useAuth from '@/lib/auth';
+
+const DashboardTable = ({
+  squads,
+  match,
+  maximumParticipated,
+  setMaximumParticipated,
+  participants,
+  setParticipants,
+  setSquads,
+  auth,
+  teamsPerUser,
+  decreaseSlots,
+  contestId,
+  isModal,
+  contestPage,
+  contestName,
+}: {
+  squads: PlayerSquad[] | null;
+  match: Match;
+  maximumParticipated: boolean;
+  setMaximumParticipated: React.Dispatch<React.SetStateAction<boolean>>;
+  setParticipants: React.Dispatch<React.SetStateAction<number | null>>;
+  setSquads: React.Dispatch<React.SetStateAction<any>>;
+  decreaseSlots: () => void;
+  participants: number | null;
+  auth: Auth;
+  teamsPerUser: number;
+  contestId: string | null;
+  isModal?: boolean;
+  contestPage?: boolean;
+  contestName?: string;
+}) => {
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [selectedSquad, setSelectedSquad] = useState<null | string>(null);
+  const [isParticipating, setIsParticipating] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
+
+  function toggleTeams() {
+    setIsOpen((prev) => !prev);
+  }
+  async function addParticipant() {
+    // logger(contestId,"hdsagfhgsadjhgfsadfsadfasd");
+    // return;
+    if (!match?.id) return logger(match, 'no match id');
+    setIsParticipating(true);
+    try {
+
+
+      const added: { err?: any; ok?: string } =
+        await auth.actor.addParticipant(contestId, selectedSquad,getTimeZone());
+
+      if (added?.ok) {
+        decreaseSlots();
+        toast.success('Joined Successfully');
+        if ( participants  != null && participants + 1 >= teamsPerUser){
+
+          setMaximumParticipated(true);
+        }
+        setParticipants((prev) => (prev!=null ? ++prev : prev));
+        // match && match.teamsJoined++;
+        // let newSquads = playerSquads.filter(());
+        setSquads((prev: any) => {
+          return prev.map((squad: any) => {
+            if (squad.id == selectedSquad) {
+              return {
+                ...squad,
+                hasParticipated: true,
+              };
+            }
+            return squad;
+          });
+        });
+        handleHideConfirm();
+      } else if (added?.err) {
+        toast.error("Unexpected Error");
+      }
+      logger(added);
+    } catch (error) {
+      toast.error('Unexpected Error');
+      logger(error);
+    }
+    setSelectedSquad(null);
+    setIsParticipating(false);
+  }
+
+  const handleShowConfirm = (id: string) => {
+    setSelectedSquad(id);
+    setShowConfirm(true);
+  };
+  const handleHideConfirm = () => setShowConfirm(false);
+  return (
+    <>
+      <div className='table-p'>
+        {!isModal && (
+          <div className='text-center'>
+            <h6 className='m-0' onClick={toggleTeams}>
+              {isOpen ? 'Hide' : 'Show'}{' '}
+              <i className={`fa fa-angle-double-${isOpen ? 'up' : 'down'}`}></i>
+            </h6>
+          </div>
+        )}
+        {isOpen && (
+          <div className='table-container maxheight contestTeamtable'>
+            <div className='table-inner-container'>
+              <Table className='table' onClick={(e) => e.stopPropagation()}>
+                <thead>
+                  <tr>
+                    {/* <th className='text-center mr-5 pe-5'>Action</th> */}
+                    <th className='text-center '>Action</th>
+                    <th className='text-center'>Team </th>
+                    {!contestPage && <th>Points</th>}
+                    <th>Rank</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+
+                {
+                  <tbody>
+                    {squads?.map((squad) => {
+                      const loading =
+                        isParticipating && squad.id == selectedSquad;
+                      let status = 'Not joined';
+                      const kickedOff = isInPast(match?.time);
+                      let maximum = false;
+                      let show = false;
+                      const finished =
+                        match?.status == MatchStatusNames.finished;
+                      let buttonText = JoinContestText.upcoming;
+                      if (kickedOff) buttonText = JoinContestText.ongoing;
+                      if (finished) buttonText = JoinContestText.finished;
+                      if (squad.hasParticipated) {
+                        buttonText = JoinContestText.participated;
+                        status = JoinContestText.participated;
+                      }
+                      if (maximumParticipated && !squad.hasParticipated) {
+                        maximum = true;
+                        buttonText =
+                          contestName == 'free'
+                            ? `${participants} / ${teamsPerUser} Joined`
+                            : `${participants} Joined`;
+                        // status = `${participants} / ${match?.teamsPerUser} Max Joined`;
+                      }
+                      const disabled =
+                        isParticipating ||
+                        kickedOff ||
+                        squad.hasParticipated ||
+                        maximum;
+
+                      return (
+                        <TeamRow
+                          time={Number(match.time)}
+                          handleShowConfirm={handleShowConfirm}
+                          squad={squad}
+                          contestId={contestId}
+                          loading={loading}
+                          disabled={disabled}
+                          buttonText={buttonText}
+                          status={status}
+                          contestPage={contestPage}
+                        />
+                      );
+                    })}
+                  </tbody>
+                }
+              </Table>
+            </div>
+          </div>
+        )}
+      </div>
+      {/* </div> */}
+    </>
+  );
+};
+
+export default DashboardTable;

--- a/src/components/Components/JoinContest.tsx
+++ b/src/components/Components/JoinContest.tsx
@@ -1,0 +1,213 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { date, object, string, number, array } from 'yup';
+import {
+  Nav,
+  Navbar,
+  NavDropdown,
+  Spinner,
+  Modal,
+  Form,
+  Button,
+  Table,
+  Tab,
+} from 'react-bootstrap';
+import {
+  ErrorMessage,
+  Field,
+  Formik,
+  Form as FormikForm,
+  FormikProps,
+  FormikValues,
+  FormikHelpers,
+  useFormikContext,
+  FieldArray,
+} from 'formik';
+import {
+  MAX_NAME_CHARACTERS,
+  MIN_NAME_CHARACTERS,
+  Messages,
+  ONLY_ALPHABET,
+  Validations,
+} from '@/constant/validations';
+import logger from '@/lib/logger';
+import { useAuthStore } from '@/store/useStore';
+import { ConnectPlugWalletSlice } from '@/types/store';
+import { toast } from 'react-toastify';
+import Link from 'next/link';
+import { TEAM_CREATION_ROUTE } from '@/constant/routes';
+import {
+  fetchMatch,
+  getRawPlayerSquads,
+  
+  isConnected,
+  isInPast,
+} from '../utils/fantasy';
+import {  Match, PlayerSquad } from '@/types/fantasy';
+import DashboardTable from './DashboardTable';
+import ConnectModal from './ConnectModal';
+import { useRouter } from 'next/navigation';
+
+// import { getRawPlayerSquads } from '../utils/fantasy';
+
+interface Props {
+  matchId: string;
+  contestId: string;
+  match: Match | null;
+  teamsPerUser: number;
+  // contest: Contest;
+  isModal?: boolean;
+  decreaseSlots: () => void;
+  contestPage?: boolean;
+  updateSquad?: boolean;
+  contestName?: string;
+}
+const JoinContest = ({
+  matchId,
+  contestId,
+  contestName,
+  match,
+  teamsPerUser,
+  decreaseSlots,
+  isModal,
+  contestPage,
+  updateSquad,
+}: Props) => {
+  const [playerSquads, setPlayerSquads] = useState<any>([]);
+  const [showConnect, setShowConnect] = useState(false);
+  const [isParticipating, setIsParticipating] = useState(false);
+  const [participants, setParticipants] = useState<null | number>(null);
+  const [maximumParticipated, setMaximumParticipated] =
+    useState<boolean>(false);
+  const { auth, userAuth } = useAuthStore((state) => ({
+    auth: (state as ConnectPlugWalletSlice).auth,
+    userAuth: (state as ConnectPlugWalletSlice).userAuth,
+  }));
+  const [path, setPath] = useState<string | null>(null);
+  let router = useRouter();
+  const [squads, setSquads] = useState<PlayerSquad[] | null>(null);
+  function handleShowConnect() {
+    setShowConnect(true);
+  }
+  function handleHideConnect() {
+    setShowConnect(false);
+  }
+  /**
+   * clickRef use as a callback route user connection modal should route after connection
+   */
+  let clickRef = () => {
+    if (path) {
+      router.push(path);
+    }
+  };
+  async function getListPlayerSquads() {
+    try {
+      //   const resp = await actor.getPlayerSquadsByMatchId(matchId);
+      getRawPlayerSquads(
+        matchId,
+        auth.actor,
+        teamsPerUser,
+        setPlayerSquads,
+        setParticipants,
+        setMaximumParticipated,
+        contestId,
+      );
+      // const resp = await auth.actor.getListPlayerSquadsByMatch(matchId);
+      // logger(resp, 'dis ss this it');
+      // let _participants = 0;
+      // const _playerSquads = resp?.map((squad: any) => {
+      //   if (squad[1].hasParticipated) _participants++;
+      //   return {
+      //     ...squad[1],
+      //     id: squad[0],
+      //   };
+      // });
+
+      // setParticipants(_participants);
+      // if (_participants >= teamsPerUser) setMaximumParticipated(true);
+
+      // set(_participants)
+      // setPlayerSquads(_playerSquads);
+    } catch (error) {
+      logger(error, 'getting it err');
+    }
+  }
+  useEffect(() => {
+    if (auth.state == 'initialized' && matchId) {
+      getListPlayerSquads();
+    }
+  }, [auth, matchId]);
+  useEffect(() => {
+    if (!updateSquad) {
+      getListPlayerSquads();
+    }
+  }, [updateSquad]);
+  return (
+    <>
+      <>
+        {/* <h5 className='Nasalization text-white padding-heading'>
+          My <span>Teams</span>
+        </h5> */}
+        <ul className='join-contest-list'>
+          {playerSquads.length !== 0 && match ? (
+            <DashboardTable
+              // contest={contest as any}
+              setSquads={setPlayerSquads}
+              setParticipants={setParticipants}
+              setMaximumParticipated={setMaximumParticipated}
+              teamsPerUser={teamsPerUser}
+              maximumParticipated={maximumParticipated}
+              participants={participants}
+              auth={auth}
+              squads={playerSquads}
+              match={match}
+              decreaseSlots={decreaseSlots}
+              contestId={contestId}
+              isModal={isModal}
+              contestPage={contestPage}
+              contestName={contestName}
+            />
+          ) : (
+            <>
+              <tr className='d-flex justify-content-center mt-2'>
+                <td className='no-bg ' colSpan={6}>
+                  <div className='d-flex justify-content-center team-message'>
+                    <p className='me-2'>No Team Created, </p>
+
+                    <Link
+                      href={
+                        isConnected(auth.state)
+                          ? `${TEAM_CREATION_ROUTE}?matchId=${match?.id}`
+                          : '#'
+                      }
+                      onClick={() => {
+                        if (!isConnected(auth.state)) {
+                          handleShowConnect();
+                          if (match && Number(match.time) > Date.now()) {
+                            setPath(
+                              `${TEAM_CREATION_ROUTE}?matchId=${match?.id}`,
+                            );
+                          }
+                        }
+                      }}
+                    >
+                      Create Team
+                    </Link>
+                  </div>{' '}
+                </td>
+              </tr>
+            </>
+          )}
+        </ul>
+      </>
+
+      <ConnectModal
+        show={showConnect}
+        hideModal={handleHideConnect}
+        callBackfn={clickRef}
+      />
+    </>
+  );
+};
+
+export default JoinContest;

--- a/src/components/Components/JoinContestModal.tsx
+++ b/src/components/Components/JoinContestModal.tsx
@@ -1,0 +1,351 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Formik,
+  FormikProps,
+  Form as FormikForm,
+  Field,
+  FormikValues,
+  ErrorMessage,
+} from 'formik';
+import {
+  Button,
+  Dropdown,
+  Form,
+  Modal,
+  Nav,
+  NavDropdown,
+  NavLink,
+  Spinner,
+} from 'react-bootstrap';
+import { number, object, string } from 'yup';
+import { Principal } from '@dfinity/principal';
+import useAuth from '@/lib/auth';
+import { E8S, GAS_FEE, GAS_FEE_ICP } from '@/constant/fantasticonst';
+import { makeICPLedgerCanister } from '@/dfx/service/actor-locator';
+import { toast } from 'react-toastify';
+import { useAuthStore } from '@/store/useStore';
+import { ConnectPlugWalletSlice } from '@/types/store';
+import { AccountIdentifier } from '@dfinity/ledger-icp';
+import logger from '@/lib/logger';
+import JoinContest from './JoinContest';
+import { Match } from '@/types/fantasy';
+import {
+  getRawPlayerSquads,
+  getTimeZone,
+  handleTransferError,
+  isConnected,
+} from '../utils/fantasy';
+import { approveTokens, toE8S } from '@/lib/ledger';
+import { TransferFromError } from '@dfinity/ledger-icp/dist/candid/ledger';
+import ConfirmTransaction from './ConfirmTransaction';
+import Link from 'next/link';
+import { TEAM_CREATION_ROUTE } from '@/constant/routes';
+import ConnectModal from './ConnectModal';
+import { useRouter } from 'next/navigation';
+// import { AccountIdentifier } from '@dfinity/ledger-icp';
+
+interface Props {
+  matchId: string;
+  contestId: string;
+  entryFee: number;
+  match: Match | null;
+  teamsPerUser: number;
+  // contest: Contest;
+  decreaseSlots: () => void;
+  show: boolean;
+  handleClose: () => void;
+}
+interface SelectedTeam {
+  teamId: string | null;
+  teamName: string | null;
+}
+const JoinContestModal = ({
+  matchId,
+  contestId,
+  // contest,
+  match,
+  entryFee,
+  teamsPerUser,
+  decreaseSlots,
+  show,
+  handleClose,
+}: Props) => {
+  const [playerSquads, setPlayerSquads] = useState<any>([]);
+  const { auth, userAuth } = useAuthStore((state) => ({
+    auth: (state as ConnectPlugWalletSlice).auth,
+    userAuth: (state as ConnectPlugWalletSlice).userAuth,
+  }));
+  const [isParticipating, setIsParticipating] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [showConnect, setShowConnect] = useState(false);
+  const [path, setPath] = useState<string | null>(null);
+  let router = useRouter();
+
+  const [maximumParticipated, setMaximumParticipated] =
+    useState<boolean>(false);
+  const [participants, setParticipants] = useState<null | number>(null);
+  const [selectTeam, setSelectTeam] = useState<SelectedTeam>({
+    teamName: null,
+    teamId: null,
+  });
+  const { updateBalance } = useAuth();
+
+  async function getListPlayerSquads() {
+    try {
+      getRawPlayerSquads(
+        matchId,
+        auth.actor,
+        teamsPerUser,
+        setPlayerSquads,
+        setParticipants,
+        setMaximumParticipated,
+        contestId,
+      );
+    } catch (error) {
+      logger(error, 'getting it err');
+    }
+  }
+  async function addParticipant() {
+    
+    if (!match?.id) return logger(match, 'no match id');
+    setIsParticipating(true);
+    try {
+      logger({ entry: entryFee, GAS_FEE }, 'apprinving');
+      if (entryFee !== 0) {
+        let approve = await approveTokens(
+          toE8S(entryFee) + GAS_FEE,
+          auth.identity,
+        );
+        if (!approve) {
+          return toast.error('Unexpected Error');
+        }
+      }
+      if (!selectTeam.teamId || !contestId) return;
+      const added: { err?: TransferFromError; ok?: string } =
+        await auth.actor.addParticipant(contestId, selectTeam.teamId,getTimeZone());
+
+      if (added?.ok) {
+        decreaseSlots();
+        toast.success('Joined Successfully');
+        if (participants !=null && participants + 1 >= teamsPerUser)
+          setMaximumParticipated(true);
+        setParticipants((prev) => (prev!=null ? ++prev : prev));
+        // match && match.teamsJoined++;
+
+        // let newSquads = playerSquads.filter(())
+        setPlayerSquads((prev: any) => {
+          return prev.map((squad: any) => {
+            if (squad.id == selectTeam.teamId) {
+              return {
+                ...squad,
+                hasParticipated: true,
+              };
+            }
+            return squad;
+          });
+        });
+        logger(
+          { selectId: selectTeam.teamId, teams: playerSquads, participants },
+          'hsjdagfkjhsagdkjfdsafsad',
+        );
+
+        updateBalance();
+        handleHideConfirm();
+        handleClose();
+      } else if (added?.err) {
+        toast.error(handleTransferError(added?.err));
+      }
+      logger(added);
+    } catch (error) {
+      toast.error('Unexpected Error');
+      logger(error);
+    }
+    setSelectTeam({ teamId: null, teamName: null });
+    setIsParticipating(false);
+  }
+  const handleHideConfirm = () => setShowConfirm(false);
+
+  const handleShowConfirm = () => {
+    setShowConfirm(true);
+  };
+  /**
+   * clickRef use as a callback route user connection modal should route after connection
+   */
+  let clickRef = () => {
+    if (path) {
+      router.push(path);
+    }
+  };
+  function handleHideConnect() {
+    setShowConnect(false);
+  }
+  function handleShowConnect() {
+    setShowConnect(true);
+  }
+  useEffect(() => {
+    if (auth.state == 'initialized' && matchId) {
+      getListPlayerSquads();
+    }
+  }, [auth, matchId]);
+
+  return (
+    <>
+      <Modal
+        centered
+        show={show}
+        className='fade light'
+        onHide={() => {
+          handleClose();
+          setSelectTeam({ teamId: null, teamName: null });
+        }}
+        onClose={() => {
+          handleClose();
+          setSelectTeam({ teamId: null, teamName: null });
+        }}
+      >
+        <Modal.Body className='contestModle'>
+          <p className='modleHeading'>
+            <span>Select</span> <span>Team</span>
+          </p>
+
+          {/* <div className='contestInfoBox'>
+            <div>
+              <span>joined Teams</span>
+              <span>{participants ?? 0}</span>
+            </div>
+            <div>
+              <span>Teams Per User</span>
+              <span>{teamsPerUser ?? 0}</span>
+            </div>
+          </div> */}
+          {playerSquads && playerSquads?.length != 0 ? (
+            <div className=''>
+              <Dropdown>
+                <Dropdown.Toggle
+                  variant='success'
+                  id='dropdown-basic'
+                  className='w-100 Nasalization'
+                >
+                  {selectTeam.teamName ?? 'Select Team'}
+                </Dropdown.Toggle>
+
+                <Dropdown.Menu className='w-100'>
+                  {playerSquads &&
+                    playerSquads?.map((team: any) => {
+                      return (
+                        <Dropdown.Item
+                          className='Nasalization'
+                          defaultValue={team}
+                          key={team.id}
+                          disabled={team?.hasParticipated}
+                          onClick={() => {
+                            if (participants == teamsPerUser)
+                              return toast.error(
+                                'You have reached the maximum team limit.',
+                              );
+                            if (team?.hasParticipated)
+                              return toast.error('Already Joined');
+                            setSelectTeam({
+                              teamId: team?.id,
+                              teamName: team?.name,
+                            });
+                          }}
+                        >
+                          {team?.name}
+                        </Dropdown.Item>
+                      );
+                    })}
+                </Dropdown.Menu>
+              </Dropdown>
+
+              <Button
+                className='reg-btn my-3'
+                disabled={participants == teamsPerUser || !selectTeam.teamId}
+                onClick={handleShowConfirm}
+              >
+                Join Contest
+              </Button>
+              {/* <JoinContest
+            isModal={true}
+            entryFee={entryFee}
+            teamsPerUser={teamsPerUser}
+            contestId={contestId}
+            matchId={matchId}
+            match={match}
+            decreaseSlots={decreaseSlots}
+          /> */}
+              {participants == teamsPerUser && (
+                <p className='text-danger'>
+                  You have reached the maximum team limit.
+                </p>
+              )}
+
+              {(participants ?? 0) < teamsPerUser &&
+                playerSquads.length == participants && (
+                  <div className='d-flex align-items-center  flex-column flex-sm-row team-message'>
+                    <p className='me-2 text-danger'>
+                      You've already joined the contest{' '}
+                    </p>
+                    {match && Number(match.time) > Date.now() && (
+                      <Link
+                        href={
+                          isConnected(auth.state)
+                            ? `${TEAM_CREATION_ROUTE}?matchId=${match?.id}`
+                            : '#'
+                        }
+                        onClick={() => {
+                          if (!isConnected(auth.state)) {
+                            handleShowConnect();
+                            setPath(
+                              `${TEAM_CREATION_ROUTE}?matchId=${match?.id}`,
+                            );
+                          }
+                        }}
+                      >
+                        Create New Team.
+                      </Link>
+                    )}
+                  </div>
+                )}
+            </div>
+          ) : (
+            <div className='d-flex justify-content-center team-message'>
+              <p className='me-2 text-danger'>No Team Created, </p>
+              {match && Number(match.time) > Date.now() && (
+                <Link
+                  href={
+                    isConnected(auth.state)
+                      ? `${TEAM_CREATION_ROUTE}?matchId=${match?.id}`
+                      : '#'
+                  }
+                  onClick={() => {
+                    if (!isConnected(auth.state)) {
+                      handleShowConnect();
+                      setPath(`${TEAM_CREATION_ROUTE}?matchId=${match?.id}`);
+                    }
+                  }}
+                >
+                  Create Team
+                </Link>
+              )}
+            </div>
+          )}
+        </Modal.Body>
+      </Modal>
+      <ConfirmTransaction
+        entryFee={entryFee}
+        show={showConfirm}
+        onConfirm={addParticipant}
+        loading={isParticipating}
+        hideModal={handleHideConfirm}
+      />
+      <ConnectModal
+        show={showConnect}
+        hideModal={handleHideConnect}
+        callBackfn={clickRef}
+      />
+    </>
+  );
+};
+
+export default JoinContestModal;

--- a/src/components/Components/MatchTable.tsx
+++ b/src/components/Components/MatchTable.tsx
@@ -1,6 +1,8 @@
 import { MATCHES_ICON_SIZES } from '@/constant/fantasticonst';
 import {
   
+  ADMIN_CONTESTS_ROUTE,
+  MATCHES_CONTESTS_ROUTE,
   MATCHES_ROUTE,
   TEAM_CREATION_ROUTE,
 } from '@/constant/routes';
@@ -187,7 +189,20 @@ export default function MatchTable({
                                 Create Team
                               </Link>
                             )}
-                       
+                        {admin && (
+                              <Link
+                                href={`${ADMIN_CONTESTS_ROUTE}?matchId=${match.id}&type=${QueryParamType.simple}`}
+                                className=' reg-btn text-white reg-custom-btn empty text-capitalize  '
+                              >
+                                Create Contest
+                              </Link>
+                            )}
+                              <Link
+                              href={`${MATCHES_ROUTE + MATCHES_CONTESTS_ROUTE}?matchId=${match.id}&type=${QueryParamType.simple}`}
+                              className=' reg-btn text-white reg-custom-btn empty text-capitalize  '
+                            >
+                              View Contests
+                            </Link>
                           
                           </div>
                         </td>
@@ -358,7 +373,20 @@ export default function MatchTable({
                     Create Team
                   </Link>
                 )}
-               
+               {admin && (
+                  <Link
+                    href={`${ADMIN_CONTESTS_ROUTE}?matchId=${match.id}&type=${QueryParamType.simple}`}
+                    className=' reg-btn text-white reg-custom-btn empty text-capitalize  '
+                  >
+                    Create Contest
+                  </Link>
+                )}
+                   <Link
+                  href={`${MATCHES_ROUTE + MATCHES_CONTESTS_ROUTE}?matchId=${match.id}&type=${QueryParamType.simple}`}
+                  className=' reg-btn text-white reg-custom-btn empty text-capitalize  '
+                >
+                  View Contests
+                </Link>
 
                
               </div>

--- a/src/components/Components/TeamRow.tsx
+++ b/src/components/Components/TeamRow.tsx
@@ -1,0 +1,148 @@
+import {
+  MATCH_CONTEST_ROUTE,
+  TEAM_CREATION_ROUTE,
+  TEAMS_ROUTE,
+} from '@/constant/routes';
+import { QueryParamType, QURIES } from '@/constant/variables';
+import Link from 'next/link';
+import React from 'react';
+import { Button, Table } from 'react-bootstrap';
+import BeatLoader from 'react-spinners/BeatLoader';
+import {  isDev, sliceText } from '../utils/fantasy';
+import { Match, PlayerSquad } from '@/types/fantasy';
+import Tippy from '@tippyjs/react';
+import { useRouter } from 'next/navigation';
+import logger from '@/lib/logger';
+
+interface Props {
+  handleShowConfirm: (id: string) => void;
+  squad: PlayerSquad;
+  disabled: boolean;
+  buttonText: string;
+  loading: boolean;
+  status: string;
+  isDashboard?: boolean;
+  time: number | undefined;
+  matchId?: string;
+  contestId?: string | null;
+  contestPage?: boolean;
+  handleShowContestModel?: any;
+}
+function TeamRow({
+  handleShowConfirm,
+  time,
+  squad,
+  disabled,
+  buttonText,
+  loading,
+  status,
+  isDashboard,
+  contestId,
+  matchId,
+  contestPage,
+  handleShowContestModel,
+}: Props) {
+  let router = useRouter();
+  return (
+    <tr key={squad.id} className='border-active ds'>
+      <td className='no-bg'>
+        <div
+          className={`d-flex align-items-center justify-content-center match-action `}
+        >
+          {time && time > Date.now() ? (
+            <Link
+              className='underlined  normal small'
+              href={`${TEAM_CREATION_ROUTE}?${QURIES.squadId}=${squad.id}&${QURIES.matchId}=${squad.matchId}`}
+            >
+              {/* <i className='fa fa-edit' /> */}
+              Edit
+            </Link>
+          ) : (
+            <Link
+              className='underlined ms-2 normal small'
+              href={`${TEAMS_ROUTE}?${QURIES.squadId}=${squad.id}&${QURIES.contestId}=${contestId}&type=${QueryParamType.simple}`}
+              onClick={(e) => {
+                e.preventDefault();
+
+                if (isDashboard) {
+                  handleShowContestModel({
+                    matchId,
+                    teamId: squad.id,
+                    rankingModle: true,
+                  });
+                } else {
+                  router.push(
+                    `${TEAMS_ROUTE}?${QURIES.squadId}=${squad.id}&${QURIES.contestId}=${contestId}&type=${QueryParamType.simple}`,
+                  );
+                }
+              }}
+            >
+              {/* <i className='fa fa-eye' /> */}
+              View
+            </Link>
+          )}
+
+          {!isDev() && disabled ? null : (
+            <span
+              // onClick={() => handleShowConfirm(squad.id)}
+              onClick={() => {
+                if (matchId && handleShowContestModel) {
+                  handleShowContestModel({
+                    matchId,
+                    teamId: squad.id,
+                    rankingModle: false,
+                  });
+                } else {
+                  handleShowConfirm(squad.id);
+                }
+              }}
+              // disabled={disabled && !isDev()}
+              className='underlined ms-2 empty  text-capitalize contestbtn'
+              style={{ minWidth: '0' }}
+            >
+              {loading ? <BeatLoader color='white' size={10} /> : buttonText}
+            </span>
+          )}
+        </div>
+      </td>
+      <td
+        className='text-center truncate no-bg'
+        onClick={() => {
+          router.push(`${MATCH_CONTEST_ROUTE}matchId=${matchId}&type=0`);
+        }}
+      >
+        <Tippy content={squad.name}>
+          <span className='truncate'> {sliceText(squad.name, 0, 10)} </span>
+        </Tippy>
+      </td>
+      {!contestPage && (
+        <td
+          className='no-bg'
+          onClick={() => {
+            router.push(`${MATCH_CONTEST_ROUTE}matchId=${matchId}&type=0`);
+          }}
+        >
+          {squad.points}
+        </td>
+      )}
+      {!isDashboard && <td className='no-bg'>{squad.rank}</td>}
+      {isDashboard ? (
+        <td className='no-bg'>
+          {squad.joinedContestsName != '' ? (
+            <Tippy content={squad.joinedContestsName}>
+              <div className='truncate mxwidth'>{squad.joinedContestsName}</div>
+            </Tippy>
+          ) : (
+            <span className={`${status} status`}>{status}</span>
+          )}
+        </td>
+      ) : (
+        <td className='no-bg'>
+          <span className={`${status} status`}>{status}</span>
+        </td>
+      )}
+    </tr>
+  );
+}
+
+export default TeamRow;

--- a/src/components/Components/UpcomingMatches.tsx
+++ b/src/components/Components/UpcomingMatches.tsx
@@ -16,8 +16,8 @@ import {
   QueryParamType,
 } from '@/constant/variables';
 import { MATCHES_SLIDER_SIZES } from '@/constant/fantasticonst';
-export const MATCHES_CONTESTS_ROUTE = '/contest';
 import {
+  MATCHES_CONTESTS_ROUTE,
   MATCHES_ROUTE,
   TEAM_CREATION_ROUTE,
 } from '@/constant/routes';
@@ -93,7 +93,7 @@ export default function UpcomingMatches() {
                 {matches.upcoming?.map((match: any) => (
                   <li key={match.id}>
                     <Link
-                      href={"#"}
+                      href={`${MATCHES_ROUTE + MATCHES_CONTESTS_ROUTE}?matchId=${match.id}&type=${QueryParamType.simple}`}
                       className='upcoming-match-post'
                     >
                       <div>

--- a/src/constant/icons.ts
+++ b/src/constant/icons.ts
@@ -1,0 +1,10 @@
+import freeicon from '@/assets/images/icons/icon-free.png';
+import bronzeicon from '@/assets/images/icons/icon-bronze.png';
+import goldicon from '@/assets/images/icons/icon-gold.png';
+import { Packages } from './variables';
+
+export const PackageIcons: { [p: string]: any } = {
+  [Packages.gold]: goldicon,
+  [Packages.free]: freeicon,
+  [Packages.bronze]: bronzeicon,
+};

--- a/src/constant/routes.ts
+++ b/src/constant/routes.ts
@@ -7,3 +7,10 @@ export const SQUAD_STATS_ROUTE = '/squad-stats';
 export const MATCH_CONTEST_ROUTE = '/matches/contest?';
 export const CONTACT_US_ROUTE = '/contact-us';
 export const TEAM_CREATION_ROUTE = '/create-team';
+export const TEAMS_ROUTE = '/teams';
+export const MATCHES_CONTESTS_ROUTE = '/contest';
+export const ADMIN_ROUTE = '/admin-panel';
+export const CONTESTS_ROUTE = '/contests';
+export const ADMIN_CONTESTS_ROUTE = `${ADMIN_ROUTE+CONTESTS_ROUTE}`;
+export const API_ROUTE_GET_USD_RATE =
+  'https://api.coingecko.com/api/v3/simple/price?ids=internet-computer&vs_currencies=usd';

--- a/src/constant/validations.ts
+++ b/src/constant/validations.ts
@@ -18,16 +18,13 @@ export const Validations = {
     slots: {
       min: 1,
     },
-    entryFee: {
-      min: 0,
-    },
-    rewardDistribution: {
-      min: 1,
-    },
     minCap: {
       min: 1,
     },
     maxCap: {
+      min: 1,
+    },
+    teamsPerUser: {
       min: 1,
     },
   },
@@ -44,10 +41,6 @@ export const Messages = {
       req: `Slots are required`,
       min: `Slots ${messageTemplate.min} ${Validations.contests.slots.min}`,
     },
-    entryFee: {
-      req: `Entry Fee ${messageTemplate.req}`,
-      min: `Entry Fee can not be less than ${Validations.contests.entryFee.min}`,
-    },
     minCap: {
       req: `Min Cap ${messageTemplate.req}`,
       min: `Min Cap can not be less than ${Validations.contests.minCap.min}`,
@@ -55,6 +48,13 @@ export const Messages = {
     maxCap: {
       req: `Max Cap ${messageTemplate.req}`,
       min: `Max Cap can not be less than ${Validations.contests.maxCap.min}`,
+    },
+    teamsPerUser: {
+      req: `Teams Per User ${messageTemplate.req}`,
+      min: `Teams Per User can not be less than ${Validations.contests.teamsPerUser.min}`,
+    },
+    rules: {
+      req: `Contest Rule ${messageTemplate.req}`,
     },
   },
 };

--- a/src/constant/variables.ts
+++ b/src/constant/variables.ts
@@ -80,16 +80,34 @@ export const TRANSACTIONS_ITEMSPERPAGE = 10;
 
 export const TOP_FANTASY_PLAYERS_ITEMSPERPAGE = 4;
 export const TOP_FANTASY_PLAYERS_PAGE_ITEMSPERPAGE = 10;
-
+export const Intervals = {
+  contest: 20000,
+  ranking: 20000,
+};
 export enum QURIES {
   matchTab = 'match_tab',
   squadId = 'squadId',
   matchId = 'matchId',
   tournamentId = 'tournament',
   contestId = 'contestId',
-}
-;
+};
 
+export const JoinContestText = {
+  upcoming: 'Join',
+  ongoing: 'Match Live',
+  finished: 'Match Finished',
+  participated: 'Joined',
+};
+export const DefaultContest = {
+  name: 'FX League',
+  slots: 200,
+  teamsPerUser: 3,
+  minCap: 1,
+  maxCap: 0,
+  providerId: '0',
+  rules: `Teams Per User = ${3}
+`,
+};
 export const DefaultTeam = {
   matchId: null,
   cap: '',

--- a/src/dfx/declarations/fantasyfootball/fantasyfootball.did.js
+++ b/src/dfx/declarations/fantasyfootball/fantasyfootball.did.js
@@ -1,12 +1,83 @@
 export const idlFactory = ({ IDL }) => {
-  const Key = IDL.Text;
+  const Key__1 = IDL.Text;
+  const MonkeyId = IDL.Text;
+  const IContest = IDL.Record({
+    'teamsPerUser' : IDL.Nat,
+    'name' : IDL.Text,
+    'minCap' : IDL.Nat,
+    'slots' : IDL.Nat,
+    'matchId' : Key__1,
+    'maxCap' : IDL.Nat,
+    'providerId' : MonkeyId,
+    'rules' : IDL.Text,
+  });
+  const Result_2 = IDL.Variant({ 'ok' : IDL.Text, 'err' : IDL.Text });
+  const Tournament__1 = IDL.Record({
+    'country' : IDL.Text,
+    'endDate' : IDL.Int,
+    'name' : IDL.Text,
+    'description' : IDL.Text,
+    'providerId' : MonkeyId,
+    'startDate' : IDL.Int,
+  });
+  const Season__1 = IDL.Record({
+    'endDate' : IDL.Int,
+    'tournamentId' : Key__1,
+    'providerId' : MonkeyId,
+    'seasonName' : IDL.Text,
+    'startDate' : IDL.Int,
+  });
   const Position = IDL.Variant({
     'goalKeeper' : IDL.Null,
     'midfielder' : IDL.Null,
     'forward' : IDL.Null,
     'defender' : IDL.Null,
   });
-  const MonkeyId = IDL.Text;
+  const IPlayer = IDL.Record({
+    'id' : Key__1,
+    'country' : IDL.Text,
+    'name' : IDL.Text,
+    'fantasyPrice' : IDL.Nat,
+    'number' : IDL.Nat,
+    'photo' : IDL.Text,
+    'teamId' : Key__1,
+    'position' : Position,
+    'providerId' : MonkeyId,
+  });
+  const ITeamWithPlayers = IDL.Record({
+    'id' : IDL.Text,
+    'logo' : IDL.Text,
+    'name' : IDL.Text,
+    'seasonId' : Key__1,
+    'players' : IDL.Vec(IPlayer),
+    'shortName' : IDL.Text,
+    'providerId' : MonkeyId,
+  });
+  const MatchStatus = IDL.Text;
+  const InputMatch = IDL.Record({
+    'id' : IDL.Text,
+    'status' : MatchStatus,
+    'awayTeamName' : IDL.Text,
+    'time' : IDL.Int,
+    'seasonId' : Key__1,
+    'homeTeamName' : IDL.Text,
+    'homeScore' : IDL.Nat,
+    'awayScore' : IDL.Nat,
+    'providerId' : MonkeyId,
+    'location' : IDL.Text,
+  });
+  const Match = IDL.Record({
+    'status' : MatchStatus,
+    'homeTeam' : Key__1,
+    'time' : IDL.Int,
+    'seasonId' : Key__1,
+    'homeScore' : IDL.Nat,
+    'awayTeam' : Key__1,
+    'awayScore' : IDL.Nat,
+    'providerId' : MonkeyId,
+    'location' : IDL.Text,
+  });
+  const Key = IDL.Text;
   const RPoints = IDL.Int;
   const Player__1 = IDL.Record({
     'active' : IDL.Bool,
@@ -17,10 +88,18 @@ export const idlFactory = ({ IDL }) => {
     'number' : IDL.Nat,
     'isSub' : IDL.Bool,
     'photo' : IDL.Text,
-    'teamId' : Key,
+    'teamId' : Key__1,
     'position' : Position,
     'providerId' : MonkeyId,
     'points' : IDL.Opt(RPoints),
+  });
+  const IPlayerSquad = IDL.Record({
+    'cap' : Key__1,
+    'formation' : IDL.Text,
+    'name' : IDL.Text,
+    'viceCap' : Key__1,
+    'matchId' : Key__1,
+    'players' : IDL.Vec(IDL.Tuple(Key__1, IDL.Bool)),
   });
   const IUser = IDL.Record({ 'name' : IDL.Text, 'email' : IDL.Text });
   const Role = IDL.Variant({ 'admin' : IDL.Null, 'user' : IDL.Null });
@@ -40,44 +119,122 @@ export const idlFactory = ({ IDL }) => {
     'joiningDate' : IDL.Int,
     'email' : IDL.Text,
   });
-  const Users = IDL.Vec(IDL.Tuple(Key, User__1));
-  const Key__1 = IDL.Text;
-  const MatchStatus = IDL.Text;
+  const Users = IDL.Vec(IDL.Tuple(Key__1, User__1));
+  const Contest = IDL.Record({
+    'teamsPerUser' : IDL.Nat,
+    'name' : IDL.Text,
+    'creatorUserId' : Key__1,
+    'minCap' : IDL.Nat,
+    'slots' : IDL.Nat,
+    'matchId' : Key__1,
+    'slotsUsed' : IDL.Nat,
+    'maxCap' : IDL.Nat,
+    'providerId' : MonkeyId,
+    'rules' : IDL.Text,
+  });
   const Team__1 = IDL.Record({
     'logo' : IDL.Text,
     'name' : IDL.Text,
-    'seasonId' : Key,
+    'seasonId' : Key__1,
     'shortName' : IDL.Text,
     'providerId' : MonkeyId,
   });
   const RefinedMatch = IDL.Record({
     'status' : MatchStatus,
-    'homeTeam' : IDL.Tuple(Key, IDL.Opt(Team__1)),
+    'homeTeam' : IDL.Tuple(Key__1, IDL.Opt(Team__1)),
     'time' : IDL.Int,
-    'seasonId' : Key,
+    'seasonId' : Key__1,
     'homeScore' : IDL.Nat,
-    'awayTeam' : IDL.Tuple(Key, IDL.Opt(Team__1)),
+    'awayTeam' : IDL.Tuple(Key__1, IDL.Opt(Team__1)),
     'awayScore' : IDL.Nat,
     'providerId' : MonkeyId,
     'location' : IDL.Text,
   });
+  const Contest__1 = IDL.Record({
+    'teamsPerUser' : IDL.Nat,
+    'name' : IDL.Text,
+    'creatorUserId' : Key__1,
+    'minCap' : IDL.Nat,
+    'slots' : IDL.Nat,
+    'matchId' : Key__1,
+    'slotsUsed' : IDL.Nat,
+    'maxCap' : IDL.Nat,
+    'providerId' : MonkeyId,
+    'rules' : IDL.Text,
+  });
+  const Contests = IDL.Vec(IDL.Tuple(Key__1, Contest__1));
   const GetProps = IDL.Record({
     'status' : IDL.Text,
     'page' : IDL.Nat,
     'search' : IDL.Text,
     'limit' : IDL.Nat,
   });
+  const MatchContest = IDL.Record({
+    'teamsPerUser' : IDL.Nat,
+    'name' : IDL.Text,
+    'awayTeamName' : IDL.Text,
+    'creatorUserId' : Key__1,
+    'minCap' : IDL.Nat,
+    'slots' : IDL.Nat,
+    'matchId' : Key__1,
+    'homeTeamName' : IDL.Text,
+    'homeScore' : IDL.Nat,
+    'awayScore' : IDL.Nat,
+    'slotsUsed' : IDL.Nat,
+    'maxCap' : IDL.Nat,
+    'providerId' : MonkeyId,
+    'rules' : IDL.Text,
+    'matchName' : IDL.Text,
+  });
+  const MatchContests = IDL.Vec(IDL.Tuple(Key__1, MatchContest));
+  const ReturnContests = IDL.Record({
+    'total' : IDL.Nat,
+    'contests' : MatchContests,
+  });
+  const RawPlayerSquad = IDL.Record({
+    'cap' : Key__1,
+    'creation_time' : IDL.Int,
+    'matchTime' : IDL.Int,
+    'formation' : IDL.Text,
+    'userId' : Key__1,
+    'name' : IDL.Text,
+    'rank' : IDL.Nat,
+    'viceCap' : Key__1,
+    'hasParticipated' : IDL.Bool,
+    'matchId' : Key__1,
+    'points' : RPoints,
+    'matchName' : IDL.Text,
+  });
+  const RawPlayerSquads = IDL.Vec(IDL.Tuple(Key__1, RawPlayerSquad));
+  const ReturnTeams = IDL.Record({
+    'teams' : RawPlayerSquads,
+    'total' : IDL.Nat,
+  });
+  const ListPlayerSquad = IDL.Record({
+    'cap' : Key__1,
+    'creation_time' : IDL.Int,
+    'formation' : IDL.Text,
+    'userId' : Key__1,
+    'name' : IDL.Text,
+    'rank' : IDL.Nat,
+    'viceCap' : Key__1,
+    'hasParticipated' : IDL.Bool,
+    'joinedContestsName' : IDL.Vec(IDL.Text),
+    'matchId' : Key__1,
+    'points' : RPoints,
+  });
+  const ListPlayerSquads = IDL.Vec(IDL.Tuple(Key__1, ListPlayerSquad));
   const RTournamentMatch = IDL.Record({
-    'id' : Key,
+    'id' : Key__1,
     'status' : MatchStatus,
     'tournamentName' : IDL.Text,
-    'homeTeam' : Key,
+    'homeTeam' : Key__1,
     'time' : IDL.Int,
-    'seasonId' : Key,
+    'seasonId' : Key__1,
     'homeScore' : IDL.Nat,
-    'awayTeam' : Key,
+    'awayTeam' : Key__1,
     'awayScore' : IDL.Nat,
-    'tournamentId' : Key,
+    'tournamentId' : Key__1,
     'providerId' : MonkeyId,
     'location' : IDL.Text,
   });
@@ -85,6 +242,38 @@ export const idlFactory = ({ IDL }) => {
   const ReturnMatches = IDL.Record({
     'total' : IDL.Nat,
     'matches' : RTournamentMatches,
+  });
+  const ReturnPagContests = IDL.Record({
+    'total' : IDL.Nat,
+    'contests' : Contests,
+  });
+  const PlayerS = IDL.Record({
+    'active' : IDL.Bool,
+    'country' : IDL.Text,
+    'name' : IDL.Text,
+    'fantasyPrice' : IDL.Nat,
+    'isPlaying' : IDL.Bool,
+    'number' : IDL.Nat,
+    'isSub' : IDL.Bool,
+    'photo' : IDL.Text,
+    'teamId' : Key__1,
+    'position' : Position,
+    'providerId' : MonkeyId,
+    'points' : IDL.Opt(RPoints),
+  });
+  const RankPlayerSquad = IDL.Record({
+    'cap' : Key__1,
+    'creation_time' : IDL.Int,
+    'formation' : IDL.Text,
+    'userId' : Key__1,
+    'name' : IDL.Text,
+    'rank' : IDL.Nat,
+    'viceCap' : Key__1,
+    'hasParticipated' : IDL.Bool,
+    'matchId' : Key__1,
+    'players' : IDL.Vec(IDL.Tuple(Key__1, PlayerS, IDL.Bool)),
+    'ranks' : IDL.Vec(IDL.Tuple(Key__1, IDL.Nat)),
+    'points' : RPoints,
   });
   const Position__1 = IDL.Variant({
     'goalKeeper' : IDL.Null,
@@ -101,27 +290,43 @@ export const idlFactory = ({ IDL }) => {
     'number' : IDL.Nat,
     'isSub' : IDL.Bool,
     'photo' : IDL.Text,
-    'teamId' : Key,
+    'teamId' : Key__1,
     'position' : Position,
     'providerId' : MonkeyId,
     'points' : IDL.Opt(RPoints),
   });
-  const Players = IDL.Vec(IDL.Tuple(Key, Player));
-  const Result_2 = IDL.Variant({ 'ok' : Players, 'err' : IDL.Text });
+  const Players = IDL.Vec(IDL.Tuple(Key__1, Player));
+  const Result_4 = IDL.Variant({ 'ok' : Players, 'err' : IDL.Text });
   const PlayerCount = IDL.Record({
     'd' : IDL.Int,
     'f' : IDL.Int,
     'g' : IDL.Int,
     'm' : IDL.Int,
   });
-  const Result_1 = IDL.Variant({
+  const Result_3 = IDL.Variant({
     'ok' : IDL.Tuple(Players, PlayerCount),
     'err' : IDL.Text,
   });
+  const ISeason = IDL.Record({
+    'id' : Key__1,
+    'endDate' : IDL.Int,
+    'tournamentId' : Key__1,
+    'providerId' : MonkeyId,
+    'seasonName' : IDL.Text,
+    'startDate' : IDL.Int,
+  });
+  const Season = IDL.Record({
+    'endDate' : IDL.Int,
+    'tournamentId' : Key__1,
+    'providerId' : MonkeyId,
+    'seasonName' : IDL.Text,
+    'startDate' : IDL.Int,
+  });
+  const Seasons = IDL.Vec(IDL.Tuple(Key__1, Season));
   const Team = IDL.Record({
     'logo' : IDL.Text,
     'name' : IDL.Text,
-    'seasonId' : Key,
+    'seasonId' : Key__1,
     'shortName' : IDL.Text,
     'providerId' : MonkeyId,
   });
@@ -133,33 +338,124 @@ export const idlFactory = ({ IDL }) => {
     'providerId' : MonkeyId,
     'startDate' : IDL.Int,
   });
-  const Tournaments = IDL.Vec(IDL.Tuple(Key, Tournament));
+  const Tournaments = IDL.Vec(IDL.Tuple(Key__1, Tournament));
   const ReturnTournaments = IDL.Record({
     'total' : IDL.Nat,
     'tournaments' : Tournaments,
   });
-  const _anon_class_19_1 = IDL.Service({
+  const PlayerSquad = IDL.Record({
+    'cap' : Key__1,
+    'creation_time' : IDL.Int,
+    'formation' : IDL.Text,
+    'userId' : Key__1,
+    'name' : IDL.Text,
+    'rank' : IDL.Nat,
+    'viceCap' : Key__1,
+    'hasParticipated' : IDL.Bool,
+    'matchId' : Key__1,
+    'players' : IDL.Vec(IDL.Tuple(Key__1, IDL.Bool)),
+    'points' : RPoints,
+  });
+  const Result_1 = IDL.Variant({
+    'ok' : IDL.Record({ 'squad' : IDL.Opt(PlayerSquad), 'message' : IDL.Text }),
+    'err' : IDL.Text,
+  });
+  const _anon_class_22_1 = IDL.Service({
+    'addContest' : IDL.Func([IContest], [Result_2], []),
+    'addLeague' : IDL.Func(
+        [Tournament__1, Season__1, IDL.Vec(ITeamWithPlayers)],
+        [],
+        ['oneway'],
+      ),
+    'addMatches' : IDL.Func(
+        [IDL.Vec(InputMatch)],
+        [
+          IDL.Record({
+            'err' : IDL.Vec(IDL.Tuple(IDL.Bool, IDL.Text)),
+            'succ' : IDL.Vec(IDL.Tuple(IDL.Bool, Match)),
+          }),
+        ],
+        [],
+      ),
+    'addNewMatches' : IDL.Func(
+        [IDL.Vec(InputMatch), Key],
+        [
+          IDL.Record({
+            'err' : IDL.Vec(IDL.Tuple(IDL.Bool, IDL.Text)),
+            'succ' : IDL.Vec(IDL.Tuple(IDL.Bool, Match)),
+          }),
+        ],
+        [],
+      ),
     'addPlayer' : IDL.Func([Player__1], [], ['oneway']),
+    'addPlayerSquad' : IDL.Func([IPlayerSquad], [Result_2], []),
     'addUser' : IDL.Func([IUser], [Result], []),
     'getAdmins' : IDL.Func([], [Users], ['query']),
     'getBudget' : IDL.Func([], [IDL.Opt(IDL.Text)], ['query']),
-    'getMatch' : IDL.Func([Key__1], [IDL.Opt(RefinedMatch)], ['query']),
+    'getContest' : IDL.Func([Key], [IDL.Opt(Contest)], ['query']),
+    'getContestNames' : IDL.Func(
+        [IDL.Vec(Key)],
+        [IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))],
+        ['query'],
+      ),
+    'getContestWithMatch' : IDL.Func(
+        [Key],
+        [
+          IDL.Opt(
+            IDL.Record({ 'match' : IDL.Opt(RefinedMatch), 'contest' : Contest })
+          ),
+        ],
+        ['query'],
+      ),
+    'getContestsByMatchId' : IDL.Func([Key], [Contests], ['query']),
+    'getFilterdContests' : IDL.Func([GetProps], [ReturnContests], ['query']),
+    'getFilterdRawPlayerSquadsByMatch' : IDL.Func(
+        [IDL.Opt(Key), IDL.Opt(Key), GetProps],
+        [ReturnTeams],
+        ['query'],
+      ),
+    'getListPlayerSquadsByMatch' : IDL.Func(
+        [Key, IDL.Opt(Key)],
+        [ListPlayerSquads],
+        ['query'],
+      ),
+    'getMatch' : IDL.Func([Key], [IDL.Opt(RefinedMatch)], ['query']),
     'getMatchesWithTournamentId' : IDL.Func(
-        [GetProps, IDL.Opt(IDL.Int), IDL.Opt(Key__1)],
+        [GetProps, IDL.Opt(IDL.Int), IDL.Int, IDL.Opt(Key)],
         [ReturnMatches],
         ['query'],
       ),
-    'getPlayer' : IDL.Func([Key__1], [IDL.Opt(Player__1)], ['query']),
-    'getPlayersByPosition' : IDL.Func([Position__1], [Result_2], ['query']),
-    'getPlayersByTeamId' : IDL.Func([Key__1], [Result_1], ['query']),
-    'getPlayersByTeamIds' : IDL.Func([IDL.Vec(Key__1)], [Result_1], ['query']),
-    'getTeamById' : IDL.Func([Key__1], [IDL.Opt(Team)], ['query']),
+    'getPaginatedContestsByMatchId' : IDL.Func(
+        [Key, GetProps],
+        [ReturnPagContests],
+        ['query'],
+      ),
+    'getPlayer' : IDL.Func([Key], [IDL.Opt(Player__1)], ['query']),
+    'getPlayerSquad' : IDL.Func([Key], [IDL.Opt(RankPlayerSquad)], ['query']),
+    'getPlayersByPosition' : IDL.Func([Position__1], [Result_4], ['query']),
+    'getPlayersByTeamId' : IDL.Func([Key], [Result_3], ['query']),
+    'getPlayersByTeamIds' : IDL.Func([IDL.Vec(Key)], [Result_3], ['query']),
+    'getSeasonByProvider' : IDL.Func(
+        [MonkeyId, MonkeyId],
+        [IDL.Opt(ISeason)],
+        ['query'],
+      ),
+    'getSeasons' : IDL.Func([Key], [Seasons], ['query']),
+    'getTeamById' : IDL.Func([Key], [IDL.Opt(Team)], ['query']),
+    'getTeamByName' : IDL.Func(
+        [IDL.Text],
+        [IDL.Opt(IDL.Tuple(Key, Team))],
+        ['query'],
+      ),
+    'getTournaments' : IDL.Func([], [Tournaments], ['query']),
     'getTournamentsN' : IDL.Func([GetProps], [ReturnTournaments], ['query']),
     'getUser' : IDL.Func([IDL.Opt(IDL.Text)], [IDL.Opt(User)], ['query']),
     'makeAdmin' : IDL.Func([IDL.Principal], [IDL.Bool], []),
-    'savePlayers_mg' : IDL.Func([Players], [IDL.Bool], []),
+    'removeContest' : IDL.Func([Key], [IDL.Opt(Contest)], []),
+    'updateContest' : IDL.Func([IContest, Key], [Result_2], []),
+    'updatePlayerSquad' : IDL.Func([Key, IPlayerSquad], [Result_1], []),
     'updateUser' : IDL.Func([IUser], [Result], []),
   });
-  return _anon_class_19_1;
+  return _anon_class_22_1;
 };
 export const init = ({ IDL }) => { return []; };

--- a/src/dfx/declarations/temp/fantasyfootball/fantasyfootball.did
+++ b/src/dfx/declarations/temp/fantasyfootball/fantasyfootball.did
@@ -1,26 +1,86 @@
-type _anon_class_19_1 = 
+type _anon_class_22_1 = 
  service {
+   addContest: (IContest) -> (Result_2);
+   addLeague: (Tournament__1, Season__1, vec ITeamWithPlayers) -> () oneway;
+   addMatches: (vec InputMatch) ->
+    (record {
+       err: vec record {
+                  bool;
+                  text;
+                };
+       succ: vec record {
+                   bool;
+                   Match;
+                 };
+     });
+   addNewMatches: (vec InputMatch, Key) ->
+    (record {
+       err: vec record {
+                  bool;
+                  text;
+                };
+       succ: vec record {
+                   bool;
+                   Match;
+                 };
+     });
    addPlayer: (Player__1) -> () oneway;
+   addPlayerSquad: (IPlayerSquad) -> (Result_2);
    addUser: (IUser) -> (Result);
    getAdmins: () -> (Users) query;
    getBudget: () -> (opt text) query;
-   getMatch: (Key__1) -> (opt RefinedMatch) query;
-   getMatchesWithTournamentId: (GetProps, opt int, opt Key__1) ->
+   getContest: (Key) -> (opt Contest) query;
+   /// getContestNames use to get list of contest names og given ids
+   ///    @param array of contestIds
+   ///    @return [(id, contestname)]
+   ///   *
+   getContestNames: (vec Key) -> (vec record {
+                                        text;
+                                        text;
+                                      }) query;
+   /// getContestWithMatch use to get  contest with match with contest id
+   ///    @param array of contestId
+   ///    @return {contest:Contest;match:RefinedMatch}
+   ///   *
+   getContestWithMatch: (Key) ->
+    (opt record {
+           contest: Contest;
+           match: opt RefinedMatch;
+         }) query;
+   getContestsByMatchId: (Key) -> (Contests) query;
+   getFilterdContests: (GetProps) -> (ReturnContests) query;
+   getFilterdRawPlayerSquadsByMatch: (opt Key, opt Key, GetProps) ->
+    (ReturnTeams) query;
+   getListPlayerSquadsByMatch: (Key, opt Key) -> (ListPlayerSquads) query;
+   getMatch: (Key) -> (opt RefinedMatch) query;
+   getMatchesWithTournamentId: (GetProps, opt int, int, opt Key) ->
     (ReturnMatches) query;
-   getPlayer: (Key__1) -> (opt Player__1) query;
-   getPlayersByPosition: (Position__1) -> (Result_2) query;
-   getPlayersByTeamId: (Key__1) -> (Result_1) query;
-   getPlayersByTeamIds: (vec Key__1) -> (Result_1) query;
-   getTeamById: (Key__1) -> (opt Team) query;
+   getPaginatedContestsByMatchId: (Key, GetProps) ->
+    (ReturnPagContests) query;
+   getPlayer: (Key) -> (opt Player__1) query;
+   getPlayerSquad: (Key) -> (opt RankPlayerSquad) query;
+   getPlayersByPosition: (Position__1) -> (Result_4) query;
+   getPlayersByTeamId: (Key) -> (Result_3) query;
+   getPlayersByTeamIds: (vec Key) -> (Result_3) query;
+   getSeasonByProvider: (MonkeyId, MonkeyId) -> (opt ISeason) query;
+   getSeasons: (Key) -> (Seasons) query;
+   getTeamById: (Key) -> (opt Team) query;
+   getTeamByName: (text) -> (opt record {
+                                   Key;
+                                   Team;
+                                 }) query;
+   getTournaments: () -> (Tournaments) query;
    getTournamentsN: (GetProps) -> (ReturnTournaments) query;
    getUser: (opt text) -> (opt User) query;
    makeAdmin: (principal) -> (bool);
-   savePlayers_mg: (Players) -> (bool);
+   removeContest: (Key) -> (opt Contest);
+   updateContest: (IContest, Key) -> (Result_2);
+   updatePlayerSquad: (Key, IPlayerSquad) -> (Result_1);
    updateUser: (IUser) -> (Result);
  };
 type Users = 
  vec record {
-       Key;
+       Key__1;
        User__1;
      };
 type User__1 = 
@@ -39,9 +99,18 @@ type User =
  };
 type Tournaments = 
  vec record {
-       Key;
+       Key__1;
        Tournament;
      };
+type Tournament__1 = 
+ record {
+   country: text;
+   description: text;
+   endDate: int;
+   name: text;
+   providerId: MonkeyId;
+   startDate: int;
+ };
 type Tournament = 
  record {
    country: text;
@@ -56,7 +125,7 @@ type Team__1 =
    logo: text;
    name: text;
    providerId: MonkeyId;
-   seasonId: Key;
+   seasonId: Key__1;
    shortName: text;
  };
 type Team = 
@@ -64,8 +133,29 @@ type Team =
    logo: text;
    name: text;
    providerId: MonkeyId;
-   seasonId: Key;
+   seasonId: Key__1;
    shortName: text;
+ };
+type Seasons = 
+ vec record {
+       Key__1;
+       Season;
+     };
+type Season__1 = 
+ record {
+   endDate: int;
+   providerId: MonkeyId;
+   seasonName: text;
+   startDate: int;
+   tournamentId: Key__1;
+ };
+type Season = 
+ record {
+   endDate: int;
+   providerId: MonkeyId;
+   seasonName: text;
+   startDate: int;
+   tournamentId: Key__1;
  };
 type Role = 
  variant {
@@ -77,22 +167,50 @@ type ReturnTournaments =
    total: nat;
    tournaments: Tournaments;
  };
+type ReturnTeams = 
+ record {
+   teams: RawPlayerSquads;
+   total: nat;
+ };
+type ReturnPagContests = 
+ record {
+   contests: Contests;
+   total: nat;
+ };
 type ReturnMatches = 
  record {
    matches: RTournamentMatches;
    total: nat;
  };
-type Result_2 = 
+type ReturnContests = 
+ record {
+   contests: MatchContests;
+   total: nat;
+ };
+type Result_4 = 
  variant {
    err: text;
    ok: Players;
  };
-type Result_1 = 
+type Result_3 = 
  variant {
    err: text;
    ok: record {
          Players;
          PlayerCount;
+       };
+ };
+type Result_2 = 
+ variant {
+   err: text;
+   ok: text;
+ };
+type Result_1 = 
+ variant {
+   err: text;
+   ok: record {
+         message: text;
+         squad: opt PlayerSquad;
        };
  };
 type Result = 
@@ -107,34 +225,76 @@ type RefinedMatch =
  record {
    awayScore: nat;
    awayTeam: record {
-               Key;
+               Key__1;
                opt Team__1;
              };
    homeScore: nat;
    homeTeam: record {
-               Key;
+               Key__1;
                opt Team__1;
              };
    location: text;
    providerId: MonkeyId;
-   seasonId: Key;
+   seasonId: Key__1;
    status: MatchStatus;
    time: int;
+ };
+type RawPlayerSquads = 
+ vec record {
+       Key__1;
+       RawPlayerSquad;
+     };
+type RawPlayerSquad = 
+ record {
+   cap: Key__1;
+   creation_time: int;
+   formation: text;
+   hasParticipated: bool;
+   matchId: Key__1;
+   matchName: text;
+   matchTime: int;
+   name: text;
+   points: RPoints;
+   rank: nat;
+   userId: Key__1;
+   viceCap: Key__1;
+ };
+type RankPlayerSquad = 
+ record {
+   cap: Key__1;
+   creation_time: int;
+   formation: text;
+   hasParticipated: bool;
+   matchId: Key__1;
+   name: text;
+   players: vec record {
+                  Key__1;
+                  PlayerS;
+                  bool;
+                };
+   points: RPoints;
+   rank: nat;
+   ranks: vec record {
+                Key__1;
+                nat;
+              };
+   userId: Key__1;
+   viceCap: Key__1;
  };
 type RTournamentMatches = vec RTournamentMatch;
 type RTournamentMatch = 
  record {
    awayScore: nat;
-   awayTeam: Key;
+   awayTeam: Key__1;
    homeScore: nat;
-   homeTeam: Key;
-   id: Key;
+   homeTeam: Key__1;
+   id: Key__1;
    location: text;
    providerId: MonkeyId;
-   seasonId: Key;
+   seasonId: Key__1;
    status: MatchStatus;
    time: int;
-   tournamentId: Key;
+   tournamentId: Key__1;
    tournamentName: text;
  };
 type RPoints = int;
@@ -154,7 +314,7 @@ type Position =
  };
 type Players = 
  vec record {
-       Key;
+       Key__1;
        Player;
      };
 type Player__1 = 
@@ -170,7 +330,39 @@ type Player__1 =
    points: opt RPoints;
    position: Position;
    providerId: MonkeyId;
-   teamId: Key;
+   teamId: Key__1;
+ };
+type PlayerSquad = 
+ record {
+   cap: Key__1;
+   creation_time: int;
+   formation: text;
+   hasParticipated: bool;
+   matchId: Key__1;
+   name: text;
+   players: vec record {
+                  Key__1;
+                  bool;
+                };
+   points: RPoints;
+   rank: nat;
+   userId: Key__1;
+   viceCap: Key__1;
+ };
+type PlayerS = 
+ record {
+   active: bool;
+   country: text;
+   fantasyPrice: nat;
+   isPlaying: bool;
+   isSub: bool;
+   name: text;
+   number: nat;
+   photo: text;
+   points: opt RPoints;
+   position: Position;
+   providerId: MonkeyId;
+   teamId: Key__1;
  };
 type PlayerCount = 
  record {
@@ -192,16 +384,137 @@ type Player =
    points: opt RPoints;
    position: Position;
    providerId: MonkeyId;
-   teamId: Key;
+   teamId: Key__1;
  };
 type MonkeyId = text;
 type MatchStatus = text;
+type MatchContests = 
+ vec record {
+       Key__1;
+       MatchContest;
+     };
+type MatchContest = 
+ record {
+   awayScore: nat;
+   awayTeamName: text;
+   creatorUserId: Key__1;
+   homeScore: nat;
+   homeTeamName: text;
+   matchId: Key__1;
+   matchName: text;
+   maxCap: nat;
+   minCap: nat;
+   name: text;
+   providerId: MonkeyId;
+   rules: text;
+   slots: nat;
+   slotsUsed: nat;
+   teamsPerUser: nat;
+ };
+type Match = 
+ record {
+   awayScore: nat;
+   awayTeam: Key__1;
+   homeScore: nat;
+   homeTeam: Key__1;
+   location: text;
+   providerId: MonkeyId;
+   seasonId: Key__1;
+   status: MatchStatus;
+   time: int;
+ };
+type ListPlayerSquads = 
+ vec record {
+       Key__1;
+       ListPlayerSquad;
+     };
+type ListPlayerSquad = 
+ record {
+   cap: Key__1;
+   creation_time: int;
+   formation: text;
+   hasParticipated: bool;
+   joinedContestsName: vec text;
+   matchId: Key__1;
+   name: text;
+   points: RPoints;
+   rank: nat;
+   userId: Key__1;
+   viceCap: Key__1;
+ };
 type Key__1 = text;
 type Key = text;
+type InputMatch = 
+ record {
+   awayScore: nat;
+   awayTeamName: text;
+   homeScore: nat;
+   homeTeamName: text;
+   id: text;
+   location: text;
+   providerId: MonkeyId;
+   seasonId: Key__1;
+   status: MatchStatus;
+   time: int;
+ };
 type IUser = 
  record {
    email: text;
    name: text;
+ };
+type ITeamWithPlayers = 
+ record {
+   id: text;
+   logo: text;
+   name: text;
+   players: vec IPlayer;
+   providerId: MonkeyId;
+   seasonId: Key__1;
+   shortName: text;
+ };
+type ISeason = 
+ record {
+   endDate: int;
+   id: Key__1;
+   providerId: MonkeyId;
+   seasonName: text;
+   startDate: int;
+   tournamentId: Key__1;
+ };
+type IPlayerSquad = 
+ record {
+   cap: Key__1;
+   formation: text;
+   matchId: Key__1;
+   name: text;
+   players: vec record {
+                  Key__1;
+                  bool;
+                };
+   viceCap: Key__1;
+ };
+type IPlayer = 
+ record {
+   country: text;
+   fantasyPrice: nat;
+   id: Key__1;
+   name: text;
+   number: nat;
+   photo: text;
+   position: Position;
+   providerId: MonkeyId;
+   teamId: Key__1;
+ };
+type IContest = 
+ record {
+   matchId: Key__1;
+   maxCap: nat;
+   minCap: nat;
+   name: text;
+   providerId: MonkeyId;
+   rules: text;
+   slots: nat;
+   teamsPerUser: nat;
  };
 type GetProps = 
  record {
@@ -210,4 +523,35 @@ type GetProps =
    search: text;
    status: text;
  };
-service : () -> _anon_class_19_1
+type Contests = 
+ vec record {
+       Key__1;
+       Contest__1;
+     };
+type Contest__1 = 
+ record {
+   creatorUserId: Key__1;
+   matchId: Key__1;
+   maxCap: nat;
+   minCap: nat;
+   name: text;
+   providerId: MonkeyId;
+   rules: text;
+   slots: nat;
+   slotsUsed: nat;
+   teamsPerUser: nat;
+ };
+type Contest = 
+ record {
+   creatorUserId: Key__1;
+   matchId: Key__1;
+   maxCap: nat;
+   minCap: nat;
+   name: text;
+   providerId: MonkeyId;
+   rules: text;
+   slots: nat;
+   slotsUsed: nat;
+   teamsPerUser: nat;
+ };
+service : () -> _anon_class_22_1

--- a/src/dfx/declarations/temp/fantasyfootball/fantasyfootball.did.d.ts
+++ b/src/dfx/declarations/temp/fantasyfootball/fantasyfootball.did.d.ts
@@ -2,15 +2,141 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface Contest {
+  'teamsPerUser' : bigint,
+  'name' : string,
+  'creatorUserId' : Key__1,
+  'minCap' : bigint,
+  'slots' : bigint,
+  'matchId' : Key__1,
+  'slotsUsed' : bigint,
+  'maxCap' : bigint,
+  'providerId' : MonkeyId,
+  'rules' : string,
+}
+export interface Contest__1 {
+  'teamsPerUser' : bigint,
+  'name' : string,
+  'creatorUserId' : Key__1,
+  'minCap' : bigint,
+  'slots' : bigint,
+  'matchId' : Key__1,
+  'slotsUsed' : bigint,
+  'maxCap' : bigint,
+  'providerId' : MonkeyId,
+  'rules' : string,
+}
+export type Contests = Array<[Key__1, Contest__1]>;
 export interface GetProps {
   'status' : string,
   'page' : bigint,
   'search' : string,
   'limit' : bigint,
 }
+export interface IContest {
+  'teamsPerUser' : bigint,
+  'name' : string,
+  'minCap' : bigint,
+  'slots' : bigint,
+  'matchId' : Key__1,
+  'maxCap' : bigint,
+  'providerId' : MonkeyId,
+  'rules' : string,
+}
+export interface IPlayer {
+  'id' : Key__1,
+  'country' : string,
+  'name' : string,
+  'fantasyPrice' : bigint,
+  'number' : bigint,
+  'photo' : string,
+  'teamId' : Key__1,
+  'position' : Position,
+  'providerId' : MonkeyId,
+}
+export interface IPlayerSquad {
+  'cap' : Key__1,
+  'formation' : string,
+  'name' : string,
+  'viceCap' : Key__1,
+  'matchId' : Key__1,
+  'players' : Array<[Key__1, boolean]>,
+}
+export interface ISeason {
+  'id' : Key__1,
+  'endDate' : bigint,
+  'tournamentId' : Key__1,
+  'providerId' : MonkeyId,
+  'seasonName' : string,
+  'startDate' : bigint,
+}
+export interface ITeamWithPlayers {
+  'id' : string,
+  'logo' : string,
+  'name' : string,
+  'seasonId' : Key__1,
+  'players' : Array<IPlayer>,
+  'shortName' : string,
+  'providerId' : MonkeyId,
+}
 export interface IUser { 'name' : string, 'email' : string }
+export interface InputMatch {
+  'id' : string,
+  'status' : MatchStatus,
+  'awayTeamName' : string,
+  'time' : bigint,
+  'seasonId' : Key__1,
+  'homeTeamName' : string,
+  'homeScore' : bigint,
+  'awayScore' : bigint,
+  'providerId' : MonkeyId,
+  'location' : string,
+}
 export type Key = string;
 export type Key__1 = string;
+export interface ListPlayerSquad {
+  'cap' : Key__1,
+  'creation_time' : bigint,
+  'formation' : string,
+  'userId' : Key__1,
+  'name' : string,
+  'rank' : bigint,
+  'viceCap' : Key__1,
+  'hasParticipated' : boolean,
+  'joinedContestsName' : Array<string>,
+  'matchId' : Key__1,
+  'points' : RPoints,
+}
+export type ListPlayerSquads = Array<[Key__1, ListPlayerSquad]>;
+export interface Match {
+  'status' : MatchStatus,
+  'homeTeam' : Key__1,
+  'time' : bigint,
+  'seasonId' : Key__1,
+  'homeScore' : bigint,
+  'awayTeam' : Key__1,
+  'awayScore' : bigint,
+  'providerId' : MonkeyId,
+  'location' : string,
+}
+export interface MatchContest {
+  'teamsPerUser' : bigint,
+  'name' : string,
+  'awayTeamName' : string,
+  'creatorUserId' : Key__1,
+  'minCap' : bigint,
+  'slots' : bigint,
+  'matchId' : Key__1,
+  'homeTeamName' : string,
+  'homeScore' : bigint,
+  'awayScore' : bigint,
+  'slotsUsed' : bigint,
+  'maxCap' : bigint,
+  'providerId' : MonkeyId,
+  'rules' : string,
+  'matchName' : string,
+}
+export type MatchContests = Array<[Key__1, MatchContest]>;
 export type MatchStatus = string;
 export type MonkeyId = string;
 export interface Player {
@@ -22,7 +148,7 @@ export interface Player {
   'number' : bigint,
   'isSub' : boolean,
   'photo' : string,
-  'teamId' : Key,
+  'teamId' : Key__1,
   'position' : Position,
   'providerId' : MonkeyId,
   'points' : [] | [RPoints],
@@ -33,6 +159,33 @@ export interface PlayerCount {
   'g' : bigint,
   'm' : bigint,
 }
+export interface PlayerS {
+  'active' : boolean,
+  'country' : string,
+  'name' : string,
+  'fantasyPrice' : bigint,
+  'isPlaying' : boolean,
+  'number' : bigint,
+  'isSub' : boolean,
+  'photo' : string,
+  'teamId' : Key__1,
+  'position' : Position,
+  'providerId' : MonkeyId,
+  'points' : [] | [RPoints],
+}
+export interface PlayerSquad {
+  'cap' : Key__1,
+  'creation_time' : bigint,
+  'formation' : string,
+  'userId' : Key__1,
+  'name' : string,
+  'rank' : bigint,
+  'viceCap' : Key__1,
+  'hasParticipated' : boolean,
+  'matchId' : Key__1,
+  'players' : Array<[Key__1, boolean]>,
+  'points' : RPoints,
+}
 export interface Player__1 {
   'active' : boolean,
   'country' : string,
@@ -42,12 +195,12 @@ export interface Player__1 {
   'number' : bigint,
   'isSub' : boolean,
   'photo' : string,
-  'teamId' : Key,
+  'teamId' : Key__1,
   'position' : Position,
   'providerId' : MonkeyId,
   'points' : [] | [RPoints],
 }
-export type Players = Array<[Key, Player]>;
+export type Players = Array<[Key__1, Player]>;
 export type Position = { 'goalKeeper' : null } |
   { 'midfielder' : null } |
   { 'forward' : null } |
@@ -58,58 +211,111 @@ export type Position__1 = { 'goalKeeper' : null } |
   { 'defender' : null };
 export type RPoints = bigint;
 export interface RTournamentMatch {
-  'id' : Key,
+  'id' : Key__1,
   'status' : MatchStatus,
   'tournamentName' : string,
-  'homeTeam' : Key,
+  'homeTeam' : Key__1,
   'time' : bigint,
-  'seasonId' : Key,
+  'seasonId' : Key__1,
   'homeScore' : bigint,
-  'awayTeam' : Key,
+  'awayTeam' : Key__1,
   'awayScore' : bigint,
-  'tournamentId' : Key,
+  'tournamentId' : Key__1,
   'providerId' : MonkeyId,
   'location' : string,
 }
 export type RTournamentMatches = Array<RTournamentMatch>;
+export interface RankPlayerSquad {
+  'cap' : Key__1,
+  'creation_time' : bigint,
+  'formation' : string,
+  'userId' : Key__1,
+  'name' : string,
+  'rank' : bigint,
+  'viceCap' : Key__1,
+  'hasParticipated' : boolean,
+  'matchId' : Key__1,
+  'players' : Array<[Key__1, PlayerS, boolean]>,
+  'ranks' : Array<[Key__1, bigint]>,
+  'points' : RPoints,
+}
+export interface RawPlayerSquad {
+  'cap' : Key__1,
+  'creation_time' : bigint,
+  'matchTime' : bigint,
+  'formation' : string,
+  'userId' : Key__1,
+  'name' : string,
+  'rank' : bigint,
+  'viceCap' : Key__1,
+  'hasParticipated' : boolean,
+  'matchId' : Key__1,
+  'points' : RPoints,
+  'matchName' : string,
+}
+export type RawPlayerSquads = Array<[Key__1, RawPlayerSquad]>;
 export interface RefinedMatch {
   'status' : MatchStatus,
-  'homeTeam' : [Key, [] | [Team__1]],
+  'homeTeam' : [Key__1, [] | [Team__1]],
   'time' : bigint,
-  'seasonId' : Key,
+  'seasonId' : Key__1,
   'homeScore' : bigint,
-  'awayTeam' : [Key, [] | [Team__1]],
+  'awayTeam' : [Key__1, [] | [Team__1]],
   'awayScore' : bigint,
   'providerId' : MonkeyId,
   'location' : string,
 }
 export type Result = { 'ok' : [string, [] | [User]] } |
   { 'err' : string };
-export type Result_1 = { 'ok' : [Players, PlayerCount] } |
+export type Result_1 = {
+    'ok' : { 'squad' : [] | [PlayerSquad], 'message' : string }
+  } |
   { 'err' : string };
-export type Result_2 = { 'ok' : Players } |
+export type Result_2 = { 'ok' : string } |
   { 'err' : string };
+export type Result_3 = { 'ok' : [Players, PlayerCount] } |
+  { 'err' : string };
+export type Result_4 = { 'ok' : Players } |
+  { 'err' : string };
+export interface ReturnContests { 'total' : bigint, 'contests' : MatchContests }
 export interface ReturnMatches {
   'total' : bigint,
   'matches' : RTournamentMatches,
 }
+export interface ReturnPagContests { 'total' : bigint, 'contests' : Contests }
+export interface ReturnTeams { 'teams' : RawPlayerSquads, 'total' : bigint }
 export interface ReturnTournaments {
   'total' : bigint,
   'tournaments' : Tournaments,
 }
 export type Role = { 'admin' : null } |
   { 'user' : null };
+export interface Season {
+  'endDate' : bigint,
+  'tournamentId' : Key__1,
+  'providerId' : MonkeyId,
+  'seasonName' : string,
+  'startDate' : bigint,
+}
+export interface Season__1 {
+  'endDate' : bigint,
+  'tournamentId' : Key__1,
+  'providerId' : MonkeyId,
+  'seasonName' : string,
+  'startDate' : bigint,
+}
+export type Seasons = Array<[Key__1, Season]>;
 export interface Team {
   'logo' : string,
   'name' : string,
-  'seasonId' : Key,
+  'seasonId' : Key__1,
   'shortName' : string,
   'providerId' : MonkeyId,
 }
 export interface Team__1 {
   'logo' : string,
   'name' : string,
-  'seasonId' : Key,
+  'seasonId' : Key__1,
   'shortName' : string,
   'providerId' : MonkeyId,
 }
@@ -121,7 +327,15 @@ export interface Tournament {
   'providerId' : MonkeyId,
   'startDate' : bigint,
 }
-export type Tournaments = Array<[Key, Tournament]>;
+export interface Tournament__1 {
+  'country' : string,
+  'endDate' : bigint,
+  'name' : string,
+  'description' : string,
+  'providerId' : MonkeyId,
+  'startDate' : bigint,
+}
+export type Tournaments = Array<[Key__1, Tournament]>;
 export interface User {
   'name' : string,
   'role' : Role,
@@ -134,28 +348,69 @@ export interface User__1 {
   'joiningDate' : bigint,
   'email' : string,
 }
-export type Users = Array<[Key, User__1]>;
-export interface _anon_class_19_1 {
+export type Users = Array<[Key__1, User__1]>;
+export interface _anon_class_22_1 {
+  'addContest' : ActorMethod<[IContest], Result_2>,
+  'addLeague' : ActorMethod<
+    [Tournament__1, Season__1, Array<ITeamWithPlayers>],
+    undefined
+  >,
+  'addMatches' : ActorMethod<
+    [Array<InputMatch>],
+    { 'err' : Array<[boolean, string]>, 'succ' : Array<[boolean, Match]> }
+  >,
+  'addNewMatches' : ActorMethod<
+    [Array<InputMatch>, Key],
+    { 'err' : Array<[boolean, string]>, 'succ' : Array<[boolean, Match]> }
+  >,
   'addPlayer' : ActorMethod<[Player__1], undefined>,
+  'addPlayerSquad' : ActorMethod<[IPlayerSquad], Result_2>,
   'addUser' : ActorMethod<[IUser], Result>,
   'getAdmins' : ActorMethod<[], Users>,
   'getBudget' : ActorMethod<[], [] | [string]>,
-  'getMatch' : ActorMethod<[Key__1], [] | [RefinedMatch]>,
+  'getContest' : ActorMethod<[Key], [] | [Contest]>,
+  'getContestNames' : ActorMethod<[Array<Key>], Array<[string, string]>>,
+  'getContestWithMatch' : ActorMethod<
+    [Key],
+    [] | [{ 'match' : [] | [RefinedMatch], 'contest' : Contest }]
+  >,
+  'getContestsByMatchId' : ActorMethod<[Key], Contests>,
+  'getFilterdContests' : ActorMethod<[GetProps], ReturnContests>,
+  'getFilterdRawPlayerSquadsByMatch' : ActorMethod<
+    [[] | [Key], [] | [Key], GetProps],
+    ReturnTeams
+  >,
+  'getListPlayerSquadsByMatch' : ActorMethod<
+    [Key, [] | [Key]],
+    ListPlayerSquads
+  >,
+  'getMatch' : ActorMethod<[Key], [] | [RefinedMatch]>,
   'getMatchesWithTournamentId' : ActorMethod<
-    [GetProps, [] | [bigint], [] | [Key__1]],
+    [GetProps, [] | [bigint], bigint, [] | [Key]],
     ReturnMatches
   >,
-  'getPlayer' : ActorMethod<[Key__1], [] | [Player__1]>,
-  'getPlayersByPosition' : ActorMethod<[Position__1], Result_2>,
-  'getPlayersByTeamId' : ActorMethod<[Key__1], Result_1>,
-  'getPlayersByTeamIds' : ActorMethod<[Array<Key__1>], Result_1>,
-  'getTeamById' : ActorMethod<[Key__1], [] | [Team]>,
+  'getPaginatedContestsByMatchId' : ActorMethod<
+    [Key, GetProps],
+    ReturnPagContests
+  >,
+  'getPlayer' : ActorMethod<[Key], [] | [Player__1]>,
+  'getPlayerSquad' : ActorMethod<[Key], [] | [RankPlayerSquad]>,
+  'getPlayersByPosition' : ActorMethod<[Position__1], Result_4>,
+  'getPlayersByTeamId' : ActorMethod<[Key], Result_3>,
+  'getPlayersByTeamIds' : ActorMethod<[Array<Key>], Result_3>,
+  'getSeasonByProvider' : ActorMethod<[MonkeyId, MonkeyId], [] | [ISeason]>,
+  'getSeasons' : ActorMethod<[Key], Seasons>,
+  'getTeamById' : ActorMethod<[Key], [] | [Team]>,
+  'getTeamByName' : ActorMethod<[string], [] | [[Key, Team]]>,
+  'getTournaments' : ActorMethod<[], Tournaments>,
   'getTournamentsN' : ActorMethod<[GetProps], ReturnTournaments>,
   'getUser' : ActorMethod<[[] | [string]], [] | [User]>,
   'makeAdmin' : ActorMethod<[Principal], boolean>,
-  'savePlayers_mg' : ActorMethod<[Players], boolean>,
+  'removeContest' : ActorMethod<[Key], [] | [Contest]>,
+  'updateContest' : ActorMethod<[IContest, Key], Result_2>,
+  'updatePlayerSquad' : ActorMethod<[Key, IPlayerSquad], Result_1>,
   'updateUser' : ActorMethod<[IUser], Result>,
 }
-export interface _SERVICE extends _anon_class_19_1 {}
+export interface _SERVICE extends _anon_class_22_1 {}
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -1,5 +1,6 @@
 import {
 
+  Contest,
     Match,
     matchWithGroupedId,
   } from '@/types/fantasy';
@@ -17,6 +18,22 @@ import {
     }
     return null;
   }
+  /**
+ * Groupe Contests by match
+ * @param {null | Contest[]} contests
+ * @returns {GroupedContests}  [string,Match]
+ */
+export function groupContestsByMatch(
+  contests: null | Contest[],
+): null | [string, Contest[]][] {
+  if (!contests) return null;
+
+  // Use lodash's groupBy function
+  const grouped = _.groupBy(contests, (contest) => contest.matchId);
+
+  // Convert the grouped object into an array of key-value pairs
+  return Object.entries(grouped);
+}
   /**
    *
    * @param {null| Match[]} matches

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -12,6 +12,7 @@
 @import 'Modal';
 @import 'Header';
 @import 'Home';
+@import 'slider';
 @import 'Footer';
 @import 'Innerpages';
 @import '_toast';

--- a/src/styles/_Form.scss
+++ b/src/styles/_Form.scss
@@ -6,12 +6,46 @@ label {
 input.form-control {
   background-color: $dark-grey;
   border-color: $dark-grey;
-  height: 50px;
+  &:not(.textarea) {
+    height: 50px;
+  }
   border-radius: 10px;
+  color: rgb(255, 251, 251);
+  ::placeholder {
+    color: white;
+  }
+  &:focus {
+    box-shadow: none !important;
+  }
 }
+.form-control-custom:focus::placeholder {
+  color: black !important;
+}
+.search-input:focus::placeholder {
+  color: white !important;
+}
+
 input[type='search'] {
-  background-image: url(../assets/images/icons/icon-search.png);
+  background-image: url('https://fantasy-extreme-assets.s3.us-east-005.backblazeb2.com/Compressed/icons/icon-search.png');
   background-repeat: no-repeat;
   background-position: 10px center;
   padding-left: 40px;
+}
+.button-select {
+  background-color: $white;
+  font-family: $Nasalization;
+  max-width: 220px;
+  font-size: 18px;
+  font-weight: 400;
+  color: $black;
+  &:focus {
+    box-shadow: none !important;
+    border-color: $color;
+  }
+  &.large {
+    max-width: 300px;
+  }
+  &.small {
+    max-width: 200px;
+  }
 }

--- a/src/styles/_Innerpages.scss
+++ b/src/styles/_Innerpages.scss
@@ -675,7 +675,7 @@
     position: absolute;
     font-weight: 700;
     left: -2px;
-    top: -56px;
+    top: -50px;
     padding: 10px 15px 10px 15px;
     background-color: #3a3a3a;
     border-radius: 15px 15px 0px 0px;
@@ -814,7 +814,7 @@
     width: 100%;
     margin-top: 30px;
     margin-bottom: 30px;
-    min-height: 99px;
+    min-height: 30px;
     @media (max-width: 767px) {
       background-color: black;
       border-radius: 15px;
@@ -1216,7 +1216,7 @@
       );
     }
     .calculate-list {
-      min-height: 99px;
+      min-height: 30px;
       i {
         color: #e7ac18 !important;
       }

--- a/src/styles/_slider.scss
+++ b/src/styles/_slider.scss
@@ -1,0 +1,139 @@
+.main_slider {
+    position: relative;
+    width: 350px;
+    height: 80px;
+    border-radius: 50px;
+    background-color: #3a3a3a;
+    color: white;
+    padding-top: 14px;
+    box-shadow: 0 0 9.2px 2.75px rgba(0, 0, 0, 0.15);
+    @media (max-width: 991px) {
+      display: none;
+    }
+  
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 50%; // Adjust to center the pseudo-element
+      transform: translateX(-50%);
+      width: 85px;
+      border: 2px solid #00ff00;
+      height: 95px;
+      margin-top: -8px;
+      font-weight: 900 !important;
+      border-radius: 25px;
+      box-shadow:
+        0 0 6px 2px rgba(0, 246, 84, 0.4),
+        0 0 32px 4px rgba(0, 246, 84, 0.61);
+      background: linear-gradient(
+        to bottom,
+        rgba(45, 45, 45, 1) 0%,
+        rgba(16, 16, 16, 1) 97%
+      );
+    }
+    .react-multi-carousel-list {
+      position: static !important;
+    }
+    .react-multiple-carousel__arrow--right {
+      right: 0 !important;
+      width: 90px;
+      height: auto;
+      min-height: unset;
+      border-radius: 0 35px 35px 0;
+      top: 0px;
+      bottom: 0px;
+      background: linear-gradient(
+        to right,
+        rgba(58, 58, 58, 0.64) 0%,
+        rgba(39, 39, 39, 0.94) 82%,
+        rgba(39, 39, 39, 1) 100%
+      );
+      &:before {
+        content: '\f138' !important;
+        left: 20px;
+        font: normal normal normal 22px/1 FontAwesome !important;
+        color: rgba(255, 255, 255, 0.5);
+      }
+      &:hover {
+        background: none;
+        // background: linear-gradient(
+        //   to right,
+        //   rgba(58, 58, 58, 0.64) 0%,
+        //   rgba(39, 39, 39, 0.94) 82%,
+        //   rgba(39, 39, 39, 1) 100%
+        // );
+        &:before {
+          color: rgba(255, 255, 255, 1);
+        }
+      }
+    }
+    .react-multiple-carousel__arrow--left {
+      left: 0 !important;
+      width: 90px;
+      height: auto;
+      min-height: unset;
+      border-radius: 35px 0px 0px 35px;
+      top: 0px;
+      bottom: 0px;
+      background: linear-gradient(
+        to right,
+        rgba(39, 39, 39, 1) 0%,
+        rgba(39, 39, 39, 0.94) 18%,
+        rgba(58, 58, 58, 0.64) 100%
+      );
+      &:before {
+        content: '\f137' !important;
+        font: normal normal normal 22px/1 FontAwesome !important;
+        color: rgba(255, 255, 255, 0.5);
+        right: 20px;
+      }
+      &:hover {
+        background: linear-gradient(
+          to right,
+          rgba(39, 39, 39, 1) 0%,
+          rgba(39, 39, 39, 0.94) 18%,
+          rgba(58, 58, 58, 0.64) 100%
+        );
+        &:before {
+          color: rgba(255, 255, 255, 1);
+        }
+      }
+    }
+    .dayOfWeek {
+      font-size: 18px !important;
+      color: #cecece;
+    }
+    .date {
+      color: #cecece;
+    }
+    .react-multi-carousel-item--active {
+      .slide-item {
+        .dayOfWeek,
+        .date {
+          color: $white;
+        }
+      }
+    }
+  }
+  
+  .active_ {
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
+    padding: 10px;
+  }
+  
+  .slide-item {
+    font-size: 16px !important;
+    text-align: center;
+    z-index: 222;
+    color: #cecece;
+    text-transform: uppercase;
+  }
+  .custom_height {
+    height: 50px;
+  }
+  .custom_ {
+    height: 35px;
+  }
+  

--- a/src/types/fantasy.d.ts
+++ b/src/types/fantasy.d.ts
@@ -10,6 +10,7 @@ interface RawPlayer {
   positionString: 'goalKeeper' | 'midfielder' | 'forward' | 'defender';
   teamId: Key;
 }
+type GroupedContests = [string, GroupedContest[]];
 interface Player {
   country: string;
   id: Key;
@@ -24,6 +25,33 @@ interface Player {
   teamName: string;
   number: number;
   photo: string;
+}
+interface PlayerSquad {
+  id: string;
+  userId: string;
+  name: string;
+  matchId: string;
+  cap: string;
+  viceCap: string;
+  points: number;
+  formation: string;
+  creation_time: number;
+  rank: number;
+  matchTime?: number;
+  hasParticipated?: boolean;
+  joinedContestsName?: string;
+}
+interface Contest {
+  name: string;
+  matchId: Key;
+  creatorUserId: string;
+  id: Key;
+  slots: number;
+  slotsUsed: number;
+  slotsLeft: number;
+  minCap: number;
+  teamsPerUser: number;
+  rules: string;
 }
 interface GroupedPlayers {
   [role: string]: Player[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,12 +2663,12 @@ axe-core@=4.7.0:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
-axios@^1.4.0:
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz"
-  integrity sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==
+axios@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
   dependencies:
-    follow-redirects "^1.15.0"
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -4134,10 +4134,10 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-follow-redirects@^1.15.0:
-  version "1.15.3"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
# Contest creation, update and create team and update on each match


## Changes Implemented
### Backend
1. **Team Backend Architecture Development**
   - Designed backend architecture to store user teams for each match in a league.
   
2. **Fantasy Teams Management**
   - Developed APIs to add and update  fantasy teams for each match across different leagues.

3. **Contest Backend Architecture Design**
   - Created  models and backend structures for contest data management across league matches.

4. **Contest Management**
   - Added endpoints for creating, updating, and deleting contests for each match in a specific league.

### Frontend
1. **Team Selection Process Integration**
   - Integrated UI components for **Create Team** and **My Teams** pages for the team management process.

2. **Contest Joining Flow**
   - Implemented **Join Contest** page to allow users to join contests within matches.


## Screenshots / Demo (if applicable)
![image](https://github.com/user-attachments/assets/323df150-ab51-4fc5-b350-86c2becb0a8c)


## Checklist
- [ ] Backend functionality verified and tested
- [x] UI matches the design specifications and is fully integrated
- [ ] Code has been reviewed for best practices
- [ ] Documentation updated if needed


